### PR TITLE
create the openclaw worker dockerfile and its smoke test

### DIFF
--- a/openclaw-base/Dockerfile
+++ b/openclaw-base/Dockerfile
@@ -4,62 +4,46 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright \
     UV_PYTHON_INSTALL_DIR=/opt/python \
     PIP_BREAK_SYSTEM_PACKAGES=1
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked <<EOF
-set -e
-apt-get update
-apt-get install -y --no-install-recommends git curl jq ripgrep ca-certificates tini
-EOF
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends git curl jq ripgrep ca-certificates tini
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-RUN <<EOF
-set -e
-uv python install 3.12
-ln -sf "$(uv python find 3.12)" /usr/local/bin/python3
-chmod -R o+rX /opt/python
-EOF
+RUN uv python install 3.12 && \
+    ln -sf "$(uv python find 3.12)" /usr/local/bin/python3 && \
+    chmod -R o+rX /opt/python
 
-RUN --mount=type=cache,target=/root/.cache/pip <<EOF
-set -e
-python3 -m pip install playwright
-python3 -m playwright install chromium --with-deps
-chmod -R o+rX /opt/playwright
-EOF
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install playwright && \
+    python3 -m playwright install chromium --with-deps && \
+    chmod -R o+rX /opt/playwright
 
 RUN npm install -g openclaw@2026.5.7
 
 ARG CLOUD_CLIS
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked <<EOF
-set -e
-[ "$CLOUD_CLIS" = "true" ] || exit 0
-
-apt-get update
-apt-get install -y --no-install-recommends gnupg unzip
-
-# AWS CLI
-curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-unzip -q /tmp/awscliv2.zip -d /tmp
-/tmp/aws/install
-rm -rf /tmp/awscliv2.zip /tmp/aws
-
-# gcloud
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
-    > /etc/apt/sources.list.d/google-cloud-sdk.list
-apt-get update
-apt-get install -y --no-install-recommends google-cloud-cli
-
-# Azure CLI
-curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
-    | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ bookworm main" \
-    > /etc/apt/sources.list.d/azure-cli.list
-apt-get update
-apt-get install -y --no-install-recommends azure-cli
-
-rm -rf /var/lib/apt/lists/*
-EOF
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    if [ "$CLOUD_CLIS" = "true" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends gnupg unzip && \
+        curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+        unzip -q /tmp/awscliv2.zip -d /tmp && \
+        /tmp/aws/install && \
+        rm -rf /tmp/awscliv2.zip /tmp/aws && \
+        curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+            | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+            > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends google-cloud-cli && \
+        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+            | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg && \
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ bookworm main" \
+            > /etc/apt/sources.list.d/azure-cli.list && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends azure-cli && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
 
 USER node
 

--- a/openclaw-base/Dockerfile
+++ b/openclaw-base/Dockerfile
@@ -1,2 +1,66 @@
-FROM alpine:3.21
-RUN apk add --no-cache bash curl
+FROM node:22-bookworm-slim
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright \
+    UV_PYTHON_INSTALL_DIR=/opt/python \
+    PIP_BREAK_SYSTEM_PACKAGES=1
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked <<EOF
+set -e
+apt-get update
+apt-get install -y --no-install-recommends git curl jq ripgrep ca-certificates tini
+EOF
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+RUN <<EOF
+set -e
+uv python install 3.12
+ln -sf "$(uv python find 3.12)" /usr/local/bin/python3
+chmod -R o+rX /opt/python
+EOF
+
+RUN --mount=type=cache,target=/root/.cache/pip <<EOF
+set -e
+python3 -m pip install playwright
+python3 -m playwright install chromium --with-deps
+chmod -R o+rX /opt/playwright
+EOF
+
+RUN npm install -g openclaw@2026.5.7
+
+ARG CLOUD_CLIS
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked <<EOF
+set -e
+[ "$CLOUD_CLIS" = "true" ] || exit 0
+
+apt-get update
+apt-get install -y --no-install-recommends gnupg unzip
+
+# AWS CLI
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/awscliv2.zip /tmp/aws
+
+# gcloud
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    > /etc/apt/sources.list.d/google-cloud-sdk.list
+apt-get update
+apt-get install -y --no-install-recommends google-cloud-cli
+
+# Azure CLI
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+    | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ bookworm main" \
+    > /etc/apt/sources.list.d/azure-cli.list
+apt-get update
+apt-get install -y --no-install-recommends azure-cli
+
+rm -rf /var/lib/apt/lists/*
+EOF
+
+USER node
+
+ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/openclaw-base/smoke-test.sh
+++ b/openclaw-base/smoke-test.sh
@@ -23,16 +23,14 @@ check rg             rg --version
 check curl           curl --version
 check tini           tini -h
 
-printf 'checking chromium ... '
-python3 - <<'PYEOF' >/dev/null 2>&1 || { echo FAILED; exit 1; }
+check chromium python3 -c "
 from playwright.sync_api import sync_playwright
 with sync_playwright() as p:
     b = p.chromium.launch()
     pg = b.new_page()
-    pg.goto("data:text/html,ok")
+    pg.goto('data:text/html,ok')
     b.close()
-PYEOF
-echo ok
+"
 
 if command -v aws    >/dev/null 2>&1; then check aws    aws --version;  fi
 if command -v gcloud >/dev/null 2>&1; then check gcloud gcloud version; fi

--- a/openclaw-base/smoke-test.sh
+++ b/openclaw-base/smoke-test.sh
@@ -1,3 +1,41 @@
 #!/bin/sh
 set -e
-echo "Smoke test passed"
+
+check() {
+    printf 'checking %s ... ' "$1"
+    shift
+    if ! "$@" >/dev/null 2>&1; then
+        echo FAILED
+        exit 1
+    fi
+    echo ok
+}
+
+check python3        python3 --version
+check "python>=3.12" python3 -c "import sys; assert sys.version_info >= (3, 12)"
+check node           node --version
+check npm            npm --version
+check openclaw       openclaw --version
+check git            git --version
+check bash           bash --version
+check jq             jq --version
+check rg             rg --version
+check curl           curl --version
+check tini           tini -h
+
+printf 'checking chromium ... '
+python3 - <<'PYEOF' >/dev/null 2>&1 || { echo FAILED; exit 1; }
+from playwright.sync_api import sync_playwright
+with sync_playwright() as p:
+    b = p.chromium.launch()
+    pg = b.new_page()
+    pg.goto("data:text/html,ok")
+    b.close()
+PYEOF
+echo ok
+
+if command -v aws    >/dev/null 2>&1; then check aws    aws --version;  fi
+if command -v gcloud >/dev/null 2>&1; then check gcloud gcloud version; fi
+if command -v az     >/dev/null 2>&1; then check az     az version;     fi
+
+echo 'All smoke tests passed'


### PR DESCRIPTION
 Adds the openclaw-base worker image — the container the AWM API spawns per agent pod.

 What's included

  - `openclaw-base/Dockerfile` — builds the worker image:
  - Node 22 (`node:22-bookworm-slim`) as the base
  - Python 3.12 via uv (bypasses Debian backports entirely)
  - Playwright + Chromium, installed to `/opt/playwright` with world-readable permissions
  - `openclaw@2026.5.7` installed globally via npm
  - Common tools: `git`, `curl`, `jq`, `ripgrep`, `tini`, `bash`
  - Optional `CLOUD_CLIS=true` build arg for AWS CLI, gcloud, and Azure CLI
  - Runs as non-root `node` user
  - `tini` as PID 1 entrypoint for correct signal handling
  - `openclaw-base/smoke-test.sh` — verifies all installed tools are accessible to the node user, including a real headless Chromium launch via Playwright

Testing

Build and run smoke tests:

  `docker build -t openclaw-base:test openclaw-base/ && \
  docker run --rm \
    -v "$PWD/openclaw-base/smoke-test.sh:/smoke-test.sh:ro" \
    openclaw-base:test \
    /bin/sh /smoke-test.sh`