### PR TITLE
fix: use query params in gh api call instead of -f flags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,7 @@ jobs:
           check_workflow() {
             local workflow=$1
             local conclusion
-            conclusion=$(gh api "repos/$REPO/actions/workflows/$workflow/runs" \
-              -f head_sha="$SHA" \
-              -f per_page=1 \
+            conclusion=$(gh api "repos/$REPO/actions/workflows/$workflow/runs?head_sha=$SHA&per_page=1" \
               --jq '.workflow_runs[0].conclusion // "not_found"')
 
             if [ "$conclusion" != "success" ] && [ "$conclusion" != "not_found" ]; then


### PR DESCRIPTION
-f flags cause gh api to send a POST request body instead of GET query params, which returns 404 from the workflow runs endpoint.