### PR TITLE
fix: point ingresses at the correct cluster issuer name

### DIFF
--- a/helm/agentfarm-api/values.yaml
+++ b/helm/agentfarm-api/values.yaml
@@ -23,7 +23,7 @@ service:
 
 ingress:
   host: api.agent-farm.k8s.aai-labs.com
-  clusterIssuer: letsencrypt-prod
+  clusterIssuer: letsencrypt-http01
   tlsSecretName: agentfarm-api-tls
 
 resources:

--- a/helm/agentfarm-ui/values.yaml
+++ b/helm/agentfarm-ui/values.yaml
@@ -13,7 +13,7 @@ service:
 
 ingress:
   host: agent-farm.k8s.aai-labs.com
-  clusterIssuer: letsencrypt-prod
+  clusterIssuer: letsencrypt-http01
   tlsSecretName: agentfarm-ui-tls
 
 resources:


### PR DESCRIPTION
The cluster's ACME issuer is named letsencrypt-http01, not letsencrypt-prod. The wrong name caused cert-manager to park the Certificates after generating private keys, so Traefik served its self-signed default cert.