### PR TITLE
Af 107 use k8s sdk instead of kubectl

### DIFF
--- a/agent_plans/AF_107_plan.md
+++ b/agent_plans/AF_107_plan.md
@@ -1,0 +1,114 @@
+# AF-107 Diagnosis: Kubernetes SDK Exec/Port-Forward Migration
+
+## Summary
+
+The attempted migration from `kubectl` subprocess calls to the Kubernetes Python SDK is not working because the SDK stream helpers are not a drop-in replacement for `kubectl exec` and `kubectl port-forward`.
+
+Changing `connect_get_*` to `connect_post_*` is not the real fix. The Python SDK method name changes, but the underlying WebSocket transport still opens a `GET` upgrade handshake. Kubernetes streaming behavior is more nuanced than normal REST calls, and `kubectl` handles protocol details and fallbacks that the current SDK usage does not.
+
+## Findings
+
+- The app now calls `connect_post_namespaced_pod_exec` and `connect_post_namespaced_pod_portforward`, but `kubernetes.stream.stream()` / `portforward()` monkey-patch the SDK request layer.
+- The SDK WebSocket helper receives the generated method's HTTP verb but effectively ignores it when creating the WebSocket connection.
+- The underlying `websocket-client` handshake is hardcoded as `GET ... HTTP/1.1` with `Upgrade: websocket`.
+- Kubernetes modern WebSocket streaming starts as a GET upgrade request, then performs a synthetic `create` authorization check for subresources such as `pods/exec` and `pods/portforward`.
+- Therefore, RBAC checks returning `yes` for both `get` and `create` are necessary, but they do not prove the SDK transport is protocol-compatible.
+- Existing tests only cover Kubernetes CRUD operations. They do not exercise `exec_command`, healthz via port-forward, or proxying via port-forward.
+
+Relevant references:
+
+- https://kubernetes.io/blog/2024/08/20/websockets-transition/
+- https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/4006-transition-spdy-to-websockets
+
+## Likely Root Cause
+
+The root cause is not simple RBAC and not simply "GET vs POST".
+
+The migration removed `kubectl`, but the replacement Python SDK stream/port-forward helpers do not fully match the Kubernetes streaming behavior that `kubectl` provides. In particular, switching from `connect_get_*` to `connect_post_*` does not reliably change the actual WebSocket request behavior, and the SDK defaults may not match the cluster's expected streaming subprotocols.
+
+## Fix Options
+
+### Option A: Restore `kubectl` for exec and port-forward
+
+Recommended short-term fix.
+
+Work estimate: 1-2 hours.
+
+Changes:
+
+- Revert `exec_command` to use `kubectl exec`.
+- Revert port-forward fallback methods to use `kubectl port-forward`.
+- Add `kubectl` back to `api/Dockerfile`.
+- Keep the Kubernetes Python SDK for normal CRUD operations.
+- Add targeted smoke/integration coverage for exec and port-forward behavior.
+
+Pros:
+
+- Fastest and lowest risk.
+- Matches previous working behavior.
+- Lets `kubectl` handle Kubernetes streaming protocol differences.
+
+Cons:
+
+- Keeps the `kubectl` binary in the API image.
+- Uses subprocesses for streaming operations.
+
+### Option B: Build a custom Python streaming implementation
+
+Recommended only if removing `kubectl` is a hard requirement.
+
+Work estimate: 1-2 days minimum.
+
+Changes:
+
+- Implement explicit Kubernetes WebSocket handling for exec.
+- Handle stdout, stderr, exit-code channels, timeout behavior, and error propagation.
+- Implement port-forward channel handling correctly.
+- Negotiate the correct Kubernetes WebSocket subprotocols.
+- Test against the actual target cluster.
+
+Pros:
+
+- Removes `kubectl` dependency.
+- Keeps all Kubernetes behavior in Python code.
+
+Cons:
+
+- Higher implementation risk.
+- Port-forward protocol handling is fiddly.
+- Requires real-cluster validation, not just unit tests.
+
+### Option C: Hybrid approach
+
+Use SDK for normal CRUD, maybe SDK/custom code for exec, but restore `kubectl` for port-forward.
+
+Work estimate: half day to 1 day.
+
+Pros:
+
+- Reduces some subprocess usage.
+- Avoids the hardest part if port-forward is the main pain point.
+
+Cons:
+
+- Mixed behavior is harder to reason about.
+- Still requires careful streaming validation.
+- Not as clean as either fully restoring `kubectl` or fully implementing streaming.
+
+## Recommendation
+
+Use Option A now: restore `kubectl` for `exec` and `port-forward`, keep the Kubernetes Python SDK for ordinary CRUD operations, and add targeted integration or smoke tests for the streaming paths.
+
+The current pure-SDK replacement is deceptively small in code size but not small in behavior. The reliable fix is hours; the robust no-`kubectl` implementation is days.
+
+## Verification Plan
+
+- Confirm the runtime kubeconfig/token is the same identity used during `kubectl auth can-i` checks.
+- Add or run a smoke test for:
+  - `exec_command(..., ["cat", ...])`
+  - `_fetch_agent_healthz_via_port_forward`
+  - `_proxy_to_agent_via_port_forward`
+- Verify no 403 occurs for `pods/exec` or `pods/portforward`.
+- Run API checks after code changes:
+  - `make check-api`
+  - `make test-api`

--- a/agent_plans/AF_107_plan.md
+++ b/agent_plans/AF_107_plan.md
@@ -1,114 +1,199 @@
-# AF-107 Diagnosis: Kubernetes SDK Exec/Port-Forward Migration
+# AF-107: Replace kubectl subprocess calls with Kubernetes Python SDK
 
-## Summary
+## Goal
 
-The attempted migration from `kubectl` subprocess calls to the Kubernetes Python SDK is not working because the SDK stream helpers are not a drop-in replacement for `kubectl exec` and `kubectl port-forward`.
+Remove the `kubectl` binary dependency from the API Docker image. All Kubernetes operations must go through the official Python SDK (`kubernetes` package) instead of spawning `kubectl` subprocesses.
 
-Changing `connect_get_*` to `connect_post_*` is not the real fix. The Python SDK method name changes, but the underlying WebSocket transport still opens a `GET` upgrade handshake. Kubernetes streaming behavior is more nuanced than normal REST calls, and `kubectl` handles protocol details and fallbacks that the current SDK usage does not.
+**Acceptance criteria:**
+1. Backend uses K8s API through the Python SDK, not subprocess kubectl
+2. kubectl is removed from the API Docker image
 
-## Findings
+---
 
-- The app now calls `connect_post_namespaced_pod_exec` and `connect_post_namespaced_pod_portforward`, but `kubernetes.stream.stream()` / `portforward()` monkey-patch the SDK request layer.
-- The SDK WebSocket helper receives the generated method's HTTP verb but effectively ignores it when creating the WebSocket connection.
-- The underlying `websocket-client` handshake is hardcoded as `GET ... HTTP/1.1` with `Upgrade: websocket`.
-- Kubernetes modern WebSocket streaming starts as a GET upgrade request, then performs a synthetic `create` authorization check for subresources such as `pods/exec` and `pods/portforward`.
-- Therefore, RBAC checks returning `yes` for both `get` and `create` are necessary, but they do not prove the SDK transport is protocol-compatible.
-- Existing tests only cover Kubernetes CRUD operations. They do not exercise `exec_command`, healthz via port-forward, or proxying via port-forward.
+## What changed
 
-Relevant references:
+### Files modified
 
-- https://kubernetes.io/blog/2024/08/20/websockets-transition/
-- https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/4006-transition-spdy-to-websockets
+1. **`api/infrastructure/kubernetes/client.py`** — All kubectl subprocess calls replaced with SDK equivalents
+2. **`api/Dockerfile`** — Removed the `RUN` block that downloaded and installed kubectl (curl, ca-certificates, kubectl binary)
 
-## Likely Root Cause
+### Code changes in `client.py`
 
-The root cause is not simple RBAC and not simply "GET vs POST".
+**Removed imports:** `socket`, `subprocess`, `time`
+**Added imports:** `from kubernetes.stream import portforward as k8s_portforward`, `from kubernetes.stream import stream as k8s_stream`
 
-The migration removed `kubectl`, but the replacement Python SDK stream/port-forward helpers do not fully match the Kubernetes streaming behavior that `kubectl` provides. In particular, switching from `connect_get_*` to `connect_post_*` does not reliably change the actual WebSocket request behavior, and the SDK defaults may not match the cluster's expected streaming subprotocols.
+**Deleted methods:**
+- `_kubectl_args` — built kubectl CLI args
+- `_free_local_port` — found free TCP port for subprocess port-forward
+- `_wait_for_local_port` — polled until subprocess port-forward was ready
 
-## Fix Options
+**Replaced methods:**
 
-### Option A: Restore `kubectl` for exec and port-forward
+| Method | Old (subprocess) | New (SDK) |
+|--------|-----------------|-----------|
+| `exec_command` | `subprocess.run(["kubectl", "exec", ...])` | `k8s_stream(connect_get_namespaced_pod_exec, ...)` with `_preload_content=False` |
+| `_fetch_agent_healthz_via_port_forward` | Spawned `kubectl port-forward`, waited for TCP, made HTTP request, killed process | `k8s_portforward(connect_get_namespaced_pod_portforward, ...)` + `pf.socket()` + `conn.sock = sock` |
+| `_proxy_to_agent_via_port_forward` | Same subprocess pattern with dynamic port | Same SDK pattern with dynamic port |
 
-Recommended short-term fix.
+**Added field:** `_stream_core_v1: client.CoreV1Api` — a separate CoreV1Api backed by its own ApiClient, used exclusively for stream/portforward calls.
 
-Work estimate: 1-2 hours.
+### Method signatures & behavior — unchanged
 
-Changes:
+All three replaced methods keep identical signatures, return types, and error types (`RuntimeError`). Callers in `agents/service.py`, `conversations/service.py`, and `tool_calls/sync_service.py` are untouched. Tests mock at the method level and need no changes.
 
-- Revert `exec_command` to use `kubectl exec`.
-- Revert port-forward fallback methods to use `kubectl port-forward`.
-- Add `kubectl` back to `api/Dockerfile`.
-- Keep the Kubernetes Python SDK for normal CRUD operations.
-- Add targeted smoke/integration coverage for exec and port-forward behavior.
+---
 
-Pros:
+## Issues encountered and root causes
 
-- Fastest and lowest risk.
-- Matches previous working behavior.
-- Lets `kubectl` handle Kubernetes streaming protocol differences.
+### Issue 1: Thread-safety — monkey-patching race condition
 
-Cons:
+**Symptom:** `ApiValueError: Missing required parameter 'ports'` on `delete_namespaced_service` when deleting an agent while healthz polling was running.
 
-- Keeps the `kubectl` binary in the API image.
-- Uses subprocesses for streaming operations.
+**Root cause:** The SDK's `stream()` and `portforward()` helpers temporarily replace `api_client.request` with a WebSocket handler. When a shared `CoreV1Api` instance is used by concurrent FastAPI threads, one thread's portforward monkey-patches the `request` method that another thread's `delete_service` call then hits.
 
-### Option B: Build a custom Python streaming implementation
+**Fix:** Created a separate `_stream_core_v1` field with its own `ApiClient`, isolating the monkey-patching from the shared `_core_v1` used by regular CRUD operations.
 
-Recommended only if removing `kubectl` is a hard requirement.
+```python
+# In __post_init__:
+if self.config.k8s_kubeconfig_path:
+    stream_api_client = k8s_config.new_client_from_config(
+        config_file=self.config.k8s_kubeconfig_path
+    )
+else:
+    stream_api_client = client.ApiClient()
+self._stream_core_v1 = client.CoreV1Api(api_client=stream_api_client)
+```
 
-Work estimate: 1-2 days minimum.
+All `k8s_stream` and `k8s_portforward` calls use `self._stream_core_v1` instead of `self._core_v1`.
 
-Changes:
+### Issue 2: 403 Forbidden on exec and portforward
 
-- Implement explicit Kubernetes WebSocket handling for exec.
-- Handle stdout, stderr, exit-code channels, timeout behavior, and error propagation.
-- Implement port-forward channel handling correctly.
-- Negotiate the correct Kubernetes WebSocket subprotocols.
-- Test against the actual target cluster.
+**Symptom:** `Handshake status 403 Forbidden` — `cannot get resource "pods/exec"` and `cannot get resource "pods/portforward"` for `system:serviceaccount:agent-farm:agent-farm-user`.
 
-Pros:
+**Root cause:** HTTP-verb → RBAC-verb mismatch.
 
-- Removes `kubectl` dependency.
-- Keeps all Kubernetes behavior in Python code.
+- `kubectl exec` / `kubectl port-forward` use **SPDY protocol** which starts with an **HTTP POST**. POST maps to RBAC verb **`create`** on the subresource.
+- The Python SDK's `stream()`/`portforward()` helpers use **WebSocket protocol** which always starts with an **HTTP GET** handshake (per RFC 6455). GET maps to RBAC verb **`get`** on the subresource.
+- The ServiceAccount `agent-farm-user` only had **`create`** granted on `pods/exec`, `pods/portforward`, and `pods/attach`. It did **not** have **`get`**.
 
-Cons:
+**Why `connect_post_*` doesn't help:** The SDK method name (`connect_get_*` vs `connect_post_*`) only changes the HTTP method parameter passed to `call_api`. But the monkey-patching replaces the request handler with a WebSocket handler that ALWAYS sends HTTP GET for the handshake. The `_method` parameter is received but ignored by `websocket_call`/`portforward_call`.
 
-- Higher implementation risk.
-- Port-forward protocol handling is fiddly.
-- Requires real-cluster validation, not just unit tests.
+**Why `kubectl auth can-i get pods/exec` returned `yes` (false positive):** `kubectl auth can-i` does not reliably evaluate subresources. When you pass `pods/exec`, it effectively evaluates against the parent `pods` resource (which the SA does have `get` on), returning `yes` even though no `get` grant exists on the `pods/exec` subresource. The authoritative checks are:
+- `kubectl auth can-i --list` — shows `pods/exec [create]` only, no `get`
+- Raw `SelfSubjectAccessReview` — `get = false`, `create = true`
 
-### Option C: Hybrid approach
+**Fix:** Grant `get` verb on the subresources in the cluster RBAC:
 
-Use SDK for normal CRUD, maybe SDK/custom code for exec, but restore `kubectl` for port-forward.
+```yaml
+- apiGroups: [""]
+  resources: ["pods/exec", "pods/portforward", "pods/attach"]
+  verbs: ["get", "create"]
+```
 
-Work estimate: half day to 1 day.
+This was applied to the cluster RBAC for `agent-farm-user`.
 
-Pros:
+---
 
-- Reduces some subprocess usage.
-- Avoids the hardest part if port-forward is the main pain point.
+## Current state of the code
 
-Cons:
+### `api/infrastructure/kubernetes/client.py` — complete
 
-- Mixed behavior is harder to reason about.
-- Still requires careful streaming validation.
-- Not as clean as either fully restoring `kubectl` or fully implementing streaming.
+```python
+# Imports
+from kubernetes.stream import portforward as k8s_portforward
+from kubernetes.stream import stream as k8s_stream
 
-## Recommendation
+# Fields
+_apps_v1: client.AppsV1Api          # regular CRUD
+_core_v1: client.CoreV1Api           # regular CRUD
+_stream_core_v1: client.CoreV1Api    # exec/portforward only (isolated ApiClient)
 
-Use Option A now: restore `kubectl` for `exec` and `port-forward`, keep the Kubernetes Python SDK for ordinary CRUD operations, and add targeted integration or smoke tests for the streaming paths.
+# __post_init__ creates _stream_core_v1 with:
+#   - new_client_from_config() for kubeconfig path (avoids deep-copy auth issues)
+#   - client.ApiClient() for in-cluster (bearer tokens survive deep copy)
 
-The current pure-SDK replacement is deceptively small in code size but not small in behavior. The reliable fix is hours; the robust no-`kubectl` implementation is days.
+# exec_command: uses k8s_stream with _preload_content=False, reads channels 1/2,
+#   checks ws.returncode, raises RuntimeError on failure (same contract as before)
 
-## Verification Plan
+# _fetch_agent_healthz_via_port_forward: uses k8s_portforward + pf.socket(8081)
+# _proxy_to_agent_via_port_forward: uses k8s_portforward + pf.socket(port)
+```
 
-- Confirm the runtime kubeconfig/token is the same identity used during `kubectl auth can-i` checks.
-- Add or run a smoke test for:
-  - `exec_command(..., ["cat", ...])`
-  - `_fetch_agent_healthz_via_port_forward`
-  - `_proxy_to_agent_via_port_forward`
-- Verify no 403 occurs for `pods/exec` or `pods/portforward`.
-- Run API checks after code changes:
-  - `make check-api`
-  - `make test-api`
+### `api/Dockerfile` — complete
+
+kubectl binary installation block removed. Image no longer needs curl, ca-certificates, or kubectl.
+
+### RBAC — complete
+
+`get` verb added to `pods/exec`, `pods/portforward`, `pods/attach` for `agent-farm-user` SA.
+
+---
+
+## Callers (unchanged)
+
+| File | Method | What it executes |
+|------|--------|-----------------|
+| `agents/service.py:900` | `exec_command` | `openclaw pairing approve` |
+| `conversations/service.py:224,235,246,341` | `exec_command` | `cat`, `hermes sessions export` |
+| `tool_calls/sync_service.py:66,98,134,205` | `exec_command` | `find`, `cat`, `hermes sessions export`, `tail` |
+| `agents/service.py:1038` | `fetch_agent_healthz` | HTTP to service, fallback to portforward |
+| Multiple proxy routes | `proxy_to_agent` | HTTP to service, fallback to portforward |
+
+All callers mock `exec_command` at the method level in tests. No test changes needed.
+
+---
+
+## How the SDK exec/portforward works (reference)
+
+### exec via `k8s_stream`
+
+1. `stream()` in `stream.py` calls `_websocket_request(websocket_call, None, api_method, *args, **kwargs)`
+2. `_websocket_request` saves the original `api_client.request`, replaces it with `functools.partial(websocket_call, configuration, binary=False)`
+3. The bound API method (`connect_get_namespaced_pod_exec`) is called, which goes through `api_client.call_api()` → `api_client.__call_api()` → `api_client.request()` (now the WebSocket handler)
+4. `websocket_call` converts the URL to `wss://`, extracts the `authorization` header from the headers dict, and calls `create_websocket(configuration, url, headers)`
+5. `create_websocket` constructs a `WebSocket` with SSL opts from the configuration, sends headers (including auth), and connects
+6. The K8s API server receives the GET + Upgrade: websocket request, checks RBAC verb `get` on `pods/exec`, upgrades to WebSocket
+7. With `_preload_content=False`, the raw `WSClient` is returned. Channels: 0=stdin, 1=stdout, 2=stderr, 3=error/status
+8. `ws.returncode` parses the YAML status from channel 3
+
+### portforward via `k8s_portforward`
+
+1. Same monkey-patching flow, but `portforward_call` is used instead of `websocket_call`
+2. `portforward_call` extracts `ports` from query params, creates WebSocket, returns a `PortForward` object
+3. `pf.socket(port)` returns a socket-like object connected to the pod's port through the WebSocket tunnel
+4. Setting `conn.sock = sock` on `HTTPConnection` bypasses DNS resolution and TCP connect — traffic goes through the tunnel
+
+### Why `_stream_core_v1` needs its own ApiClient
+
+The monkey-patching (`api_client.request = websocket_call`) is NOT thread-safe. If two threads share the same `api_client`, one thread's portforward call patches `request` while another thread's `delete_service` call hits the patched handler (which expects WebSocket parameters, not REST parameters). Using a separate `ApiClient` isolates the patching.
+
+---
+
+## Verification
+
+1. **Manual test:** Run local API + UI, create/start an agent, verify:
+   - Healthz loads (tests portforward fallback)
+   - Conversations tab loads channels/messages (tests exec: `hermes sessions export`)
+   - Tool calls tab loads (tests exec: `find`, `cat`, `tail`)
+   - Agent delete works without errors (tests that CRUD isn't affected by monkey-patching)
+
+2. **Automated tests:**
+   - `make check-api` — lint/type checks pass
+   - `make test-api` — all existing tests pass (they mock at method level)
+
+3. **Grep verification:**
+   - `grep -r "subprocess" api/infrastructure/kubernetes/client.py` → no matches
+   - `grep -r "kubectl" api/infrastructure/kubernetes/client.py` → no matches
+   - `grep -r "kubectl" api/Dockerfile` → no matches
+
+---
+
+## Key lessons / gotchas for future reference
+
+1. **WebSocket is always HTTP GET.** The Python SDK method name (`connect_get_*` vs `connect_post_*`) is irrelevant — WebSocket RFC 6455 mandates GET for the handshake. RBAC must grant `get` on exec/portforward subresources for the SDK to work.
+
+2. **`kubectl auth can-i` gives false positives on subresources.** Use `kubectl auth can-i --list` or raw `SelfSubjectAccessReview` to verify subresource permissions. `can-i <verb> pods/exec` may evaluate against the parent `pods` resource.
+
+3. **`stream()`/`portforward()` monkey-patch `api_client.request`.** This is not thread-safe. Always use a separate `CoreV1Api` with its own `ApiClient` for stream operations in multi-threaded environments (like FastAPI).
+
+4. **`new_client_from_config()` vs `client.ApiClient()`:** `ApiClient()` with no args uses `Configuration.get_default_copy()` (deep copy). `new_client_from_config()` loads the kubeconfig into a fresh Configuration without deep-copying. Both work for static bearer tokens, but `new_client_from_config` is safer for exec-based auth providers.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,11 +5,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
-    && curl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-    && chmod +x kubectl && mv kubectl /usr/local/bin/ \
-    && apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
-
 RUN pip install --no-cache-dir uv==0.4.15
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/api/infrastructure/kubernetes/client.py
+++ b/api/infrastructure/kubernetes/client.py
@@ -252,7 +252,7 @@ class KubernetesClient:
 
     def exec_command(self, pod_name: str, namespace: str, command: list[str]) -> str:
         ws = k8s_stream(
-            self._stream_core_v1.connect_post_namespaced_pod_exec,
+            self._stream_core_v1.connect_get_namespaced_pod_exec,
             pod_name,
             namespace,
             command=command,
@@ -296,7 +296,7 @@ class KubernetesClient:
             raise RuntimeError(f"No running pod found for {service_name}")
 
         pf = k8s_portforward(
-            self._stream_core_v1.connect_post_namespaced_pod_portforward,
+            self._stream_core_v1.connect_get_namespaced_pod_portforward,
             pod_name,
             namespace,
             ports=str(8081),
@@ -351,7 +351,7 @@ class KubernetesClient:
             raise RuntimeError(f"No running pod found for {service_name}")
 
         pf = k8s_portforward(
-            self._stream_core_v1.connect_post_namespaced_pod_portforward,
+            self._stream_core_v1.connect_get_namespaced_pod_portforward,
             pod_name,
             namespace,
             ports=str(port),

--- a/api/infrastructure/kubernetes/client.py
+++ b/api/infrastructure/kubernetes/client.py
@@ -21,6 +21,7 @@ class KubernetesClient:
     config: Config
     _apps_v1: client.AppsV1Api = field(init=False)
     _core_v1: client.CoreV1Api = field(init=False)
+    _stream_core_v1: client.CoreV1Api = field(init=False)
 
     def __post_init__(self) -> None:
         if self.config.k8s_kubeconfig_path:
@@ -32,6 +33,13 @@ class KubernetesClient:
                 k8s_config.load_kube_config()
         self._apps_v1 = client.AppsV1Api()
         self._core_v1 = client.CoreV1Api()
+        if self.config.k8s_kubeconfig_path:
+            stream_api_client = k8s_config.new_client_from_config(
+                config_file=self.config.k8s_kubeconfig_path
+            )
+        else:
+            stream_api_client = client.ApiClient()
+        self._stream_core_v1 = client.CoreV1Api(api_client=stream_api_client)
 
     def _create_or_get(self, create_fn, read_fn, namespace: str, manifest):
         try:
@@ -244,7 +252,7 @@ class KubernetesClient:
 
     def exec_command(self, pod_name: str, namespace: str, command: list[str]) -> str:
         ws = k8s_stream(
-            self._core_v1.connect_get_namespaced_pod_exec,
+            self._stream_core_v1.connect_post_namespaced_pod_exec,
             pod_name,
             namespace,
             command=command,
@@ -288,7 +296,7 @@ class KubernetesClient:
             raise RuntimeError(f"No running pod found for {service_name}")
 
         pf = k8s_portforward(
-            self._core_v1.connect_get_namespaced_pod_portforward,
+            self._stream_core_v1.connect_post_namespaced_pod_portforward,
             pod_name,
             namespace,
             ports=str(8081),
@@ -343,7 +351,7 @@ class KubernetesClient:
             raise RuntimeError(f"No running pod found for {service_name}")
 
         pf = k8s_portforward(
-            self._core_v1.connect_get_namespaced_pod_portforward,
+            self._stream_core_v1.connect_post_namespaced_pod_portforward,
             pod_name,
             namespace,
             ports=str(port),

--- a/api/infrastructure/kubernetes/client.py
+++ b/api/infrastructure/kubernetes/client.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 import http.client
 import json
-import socket
-import subprocess
-import time
 from dataclasses import dataclass, field
 
 from injector import inject, singleton
 from kubernetes import client
 from kubernetes import config as k8s_config
 from kubernetes.client.exceptions import ApiException
+from kubernetes.stream import portforward as k8s_portforward
+from kubernetes.stream import stream as k8s_stream
 
 from api.core.config import Config
 
@@ -244,29 +243,32 @@ class KubernetesClient:
         return None, None
 
     def exec_command(self, pod_name: str, namespace: str, command: list[str]) -> str:
-        kubectl_args = self._kubectl_args(["exec", pod_name, "-n", namespace, "--"])
-        result = subprocess.run(
-            [*kubectl_args, *command],
-            capture_output=True,
-            text=True,
-            timeout=30,
+        ws = k8s_stream(
+            self._core_v1.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            command=command,
+            stdout=True,
+            stderr=True,
+            stdin=False,
+            tty=False,
+            _preload_content=False,
+            _request_timeout=30,
         )
-        if result.returncode != 0:
-            raise RuntimeError(
-                result.stderr.strip()
-                or f"kubectl exec failed with code {result.returncode}"
-            )
-        return result.stdout
-
-    def _kubectl_args(self, args: list[str]) -> list[str]:
-        if self.config.k8s_kubeconfig_path:
-            return [
-                "kubectl",
-                "--kubeconfig",
-                self.config.k8s_kubeconfig_path,
-                *args,
-            ]
-        return ["kubectl", *args]
+        ws.run_forever(timeout=30)
+        if ws.is_open():
+            ws.close()
+            raise RuntimeError("exec timed out")
+        stdout = ws.read_channel(1)  # STDOUT_CHANNEL
+        stderr = ws.read_channel(2)  # STDERR_CHANNEL
+        try:
+            rc = ws.returncode
+        except Exception:
+            rc = -1
+        ws.close()
+        if rc != 0:
+            raise RuntimeError(stderr.strip() or f"exec failed with code {rc}")
+        return stdout
 
     def fetch_agent_healthz(self, service_name: str, namespace: str) -> dict:
         host = f"{service_name}.{namespace}"
@@ -285,25 +287,16 @@ class KubernetesClient:
         if not pod_name:
             raise RuntimeError(f"No running pod found for {service_name}")
 
-        local_port = self._free_local_port()
-        kubectl_args = self._kubectl_args(
-            [
-                "port-forward",
-                f"pod/{pod_name}",
-                "-n",
-                namespace,
-                f"{local_port}:8081",
-            ]
-        )
-        process = subprocess.Popen(
-            kubectl_args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+        pf = k8s_portforward(
+            self._core_v1.connect_get_namespaced_pod_portforward,
+            pod_name,
+            namespace,
+            ports=str(8081),
         )
         try:
-            self._wait_for_local_port(local_port, process)
-            conn = http.client.HTTPConnection("127.0.0.1", local_port, timeout=5)
+            sock = pf.socket(8081)
+            conn = http.client.HTTPConnection("localhost", 8081, timeout=5)
+            conn.sock = sock
             conn.request("GET", "/healthz")
             response = conn.getresponse()
             return json.loads(response.read())
@@ -312,12 +305,7 @@ class KubernetesClient:
                 f"healthz unreachable for {service_name}: {exc}"
             ) from exc
         finally:
-            process.terminate()
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=5)
+            pf.close()
 
     def proxy_to_agent(
         self,
@@ -354,60 +342,18 @@ class KubernetesClient:
         if not pod_name:
             raise RuntimeError(f"No running pod found for {service_name}")
 
-        local_port = self._free_local_port()
-        kubectl_args = self._kubectl_args(
-            [
-                "port-forward",
-                f"pod/{pod_name}",
-                "-n",
-                namespace,
-                f"{local_port}:{port}",
-            ]
-        )
-        process = subprocess.Popen(
-            kubectl_args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+        pf = k8s_portforward(
+            self._core_v1.connect_get_namespaced_pod_portforward,
+            pod_name,
+            namespace,
+            ports=str(port),
         )
         try:
-            self._wait_for_local_port(local_port, process)
-            conn = http.client.HTTPConnection("127.0.0.1", local_port, timeout=30)
+            sock = pf.socket(port)
+            conn = http.client.HTTPConnection("localhost", port, timeout=30)
+            conn.sock = sock
             conn.request(method, path, body=body, headers=headers)
             resp = conn.getresponse()
             return resp.status, resp.read(), dict(resp.getheaders())
         finally:
-            process.terminate()
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=5)
-
-    @staticmethod
-    def _free_local_port() -> int:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.bind(("127.0.0.1", 0))
-            return sock.getsockname()[1]
-
-    @staticmethod
-    def _wait_for_local_port(
-        port: int, process: subprocess.Popen, timeout: float = 10
-    ) -> None:
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if process.poll() is not None:
-                stdout, stderr = process.communicate()
-                raise RuntimeError(
-                    stderr.strip()
-                    or stdout.strip()
-                    or f"kubectl port-forward exited with code {process.returncode}"
-                )
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(0.25)
-                try:
-                    sock.connect(("127.0.0.1", port))
-                    return
-                except OSError:
-                    time.sleep(0.1)
-        raise RuntimeError(f"kubectl port-forward did not open localhost:{port}")
+            pf.close()

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
 version: 0.2.0
-appVersion: "0.13.0"
+appVersion: "0.14.0"


### PR DESCRIPTION
Removed kubectl dependency for pod operations. Exec and portforward now go through sdk client stream and portforward.