### PR TITLE
Af 134 create a deployment script

### DIFF
--- a/.env.deploy.spec
+++ b/.env.deploy.spec
@@ -1,0 +1,87 @@
+# Configuration for ./deploy.sh (helmfile sync).
+# Copy to .env.deploy and fill in. .env.deploy is gitignored.
+
+# ── Cluster access ───────────────────────────────────────────────────────────
+# Kubeconfig on THIS machine that helm/helmfile use to reach the cluster.
+# For k3s: copy /etc/rancher/k3s/k3s.yaml somewhere readable and point here.
+KUBECONFIG=$HOME/.kube/config
+
+# ── Container registry ───────────────────────────────────────────────────────
+REGISTRY_PREFIX=registry.k8s.aai-labs.com
+REGISTRY_SERVER=registry.k8s.aai-labs.com
+REGISTRY_USERNAME=
+REGISTRY_PASSWORD=
+
+# Image repository names under REGISTRY_PREFIX. Defaults match the internal
+# registry. The client release bundle ships these set to api/ui/hermes-base/
+# openclaw-base under REGISTRY_PREFIX=clients.registry.k8s.aai-labs.com/agent-farm.
+API_IMAGE_REPOSITORY=agentfarm-api
+UI_IMAGE_REPOSITORY=agentfarm-ui
+HERMES_IMAGE_REPOSITORY=agentfarm-hermes-base
+OPENCLAW_IMAGE_REPOSITORY=agentfarm-openclaw-base
+
+# ── Image tags (pin to specific versions for a real deploy) ──────────────────
+API_IMAGE_TAG=0.13.0
+UI_IMAGE_TAG=0.13.0
+OPENCLAW_IMAGE_TAG=0.3.0
+HERMES_IMAGE_TAG=0.1.0
+
+# ── Postgres (app DB) ────────────────────────────────────────────────────────
+POSTGRES_APP_USER=agentfarm
+POSTGRES_APP_PASSWORD=
+POSTGRES_APP_DB=agentfarm
+
+# ── Postgres (LiteLLM DB) ────────────────────────────────────────────────────
+POSTGRES_LITELLM_USER=litellm
+POSTGRES_LITELLM_PASSWORD=
+POSTGRES_LITELLM_DB=litellm
+
+# ── LiteLLM + OpenRouter ─────────────────────────────────────────────────────
+# Any strong secret prefixed with sk-; LiteLLM uses it to mint agent-scoped
+# virtual keys. Pick once and keep it stable. Generate with:
+#   echo "sk-$(openssl rand -hex 24)"
+LITELLM_MASTER_KEY=
+# Real key from your OpenRouter dashboard (sk-or-...), not generated locally.
+OPENROUTER_API_KEY=
+
+# ── API secrets ──────────────────────────────────────────────────────────────
+SECRET_SIGNING_KEY=
+# Fernet key. Generate once and keep it stable, or stored tokens can't decrypt:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+AGENT_TOKEN_ENCRYPTION_KEY=
+# Format: email:password
+SUPER_USER_CREDENTIALS=admin@example.com:
+SUPER_USER_FULL_NAME=
+ENVIRONMENT=local
+
+# ── URLs / ingress hosts ─────────────────────────────────────────────────────
+# Hostnames the ingress serves. Point DNS (or /etc/hosts) at the cluster.
+API_HOST=api.agentfarm.local
+UI_HOST=agentfarm.local
+WEB_APP_URL=http://agentfarm.local
+
+# ── Ingress TLS ──────────────────────────────────────────────────────────────
+# cert-manager ClusterIssuer that signs the api/ui ingress certs. cert-manager
+# is required. letsencrypt-http01 needs a publicly reachable host, so for a
+# local cluster install cert-manager and create a self-signed/CA ClusterIssuer,
+# then set its name here.
+INGRESS_CLUSTER_ISSUER=letsencrypt-http01
+
+# ── Storage ──────────────────────────────────────────────────────────────────
+# Empty falls through to the cluster's default StorageClass. k3s default is
+# local-path. Set to a network-replicated class for node-loss durability.
+STORAGE_CLASS=local-path
+
+# ── Model picker (AF-128) ────────────────────────────────────────────────────
+# Comma-separated fnmatch globs limiting OpenRouter models, e.g. qwen/*,openai/gpt-5*
+# Empty offers the full catalogue.
+AGENT_MODEL_ALLOWLIST=
+# Default model. Format: litellm/openrouter/<slug>
+# e.g. litellm/openrouter/qwen/qwen3.6-plus. Empty uses the API's built-in default.
+AGENT_DEFAULT_MODEL=
+
+# ── Optional ─────────────────────────────────────────────────────────────────
+# Kubeconfig the API pod uses to manage agent workloads. Defaults to base64 of
+# $KUBECONFIG (deploy.sh derives it). Set only if the API pod must use a
+# different identity or cluster than this deploy.
+# POD_KUBECONFIG_B64=

--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -13,10 +13,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Baked into the UI bundle at build time. The in-cluster Service URL is
-  # portable across any client cluster: the browser hits same-origin /api/*,
-  # and the UI server proxies to this address from inside the cluster.
-  UI_BACKEND_URL: http://agentfarm-api.agent-farm.svc.cluster.local:8000
+  # Baked into the UI bundle at build time. The bare in-cluster Service name is
+  # portable across any client cluster: the browser hits same-origin /api/*, and
+  # the UI server proxies to this address from inside the agent-farm namespace
+  # (same namespace as the API, so the short name resolves).
+  UI_BACKEND_URL: http://agentfarm-api:8000
 
 jobs:
   release:

--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -1,0 +1,118 @@
+name: Client Release
+
+# Builds every agent-farm image and pushes it to the client-facing registry.
+# Manual only. Distinct from deploy.yml: it uses the docker/* actions (no hand
+# -rolled docker login/build/push) and a matrix over the images rather than a
+# step per image.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: client-release
+  cancel-in-progress: false
+
+env:
+  # Baked into the UI bundle at build time. The in-cluster Service URL is
+  # portable across any client cluster: the browser hits same-origin /api/*,
+  # and the UI server proxies to this address from inside the cluster.
+  UI_BACKEND_URL: http://agentfarm-api.agent-farm.svc.cluster.local:8000
+
+jobs:
+  release:
+    name: Build and push ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api
+            context: .
+            file: api/Dockerfile
+            version_file: helm/agentfarm-api/Chart.yaml
+            version_kind: chart
+          - name: ui
+            context: ui
+            file: ui/Dockerfile
+            version_file: helm/agentfarm-ui/Chart.yaml
+            version_kind: chart
+          - name: hermes-base
+            context: hermes-base
+            file: hermes-base/Dockerfile
+            version_file: hermes-base/VERSION
+            version_kind: file
+            needs_token: true
+            smoke: hermes-base/smoke-test.sh
+          - name: openclaw-base
+            context: openclaw-base
+            file: openclaw-base/Dockerfile
+            version_file: openclaw-base/VERSION
+            version_kind: file
+            needs_token: true
+            smoke: openclaw-base/smoke-test.sh
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the client registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.CLIENT_REGISTRY_URL }}
+          username: ${{ secrets.CLIENT_REGISTRY_USERNAME }}
+          password: ${{ secrets.CLIENT_REGISTRY_PASSWORD }}
+
+      - name: Resolve image version
+        id: ver
+        run: |
+          if [ "${{ matrix.version_kind }}" = "chart" ]; then
+            version=$(grep '^appVersion:' "${{ matrix.version_file }}" | awk '{print $2}' | tr -d '"')
+          else
+            version=$(tr -d '[:space:]' < "${{ matrix.version_file }}")
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.CLIENT_REGISTRY_URL }}/agent-farm/${{ matrix.name }}
+          tags: |
+            type=raw,value=${{ steps.ver.outputs.version }}
+            type=raw,value=latest
+
+      # Build into the local daemon first so base images can be smoke-tested
+      # before anything is published.
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          load: true
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: ${{ matrix.name == 'ui' && format('NEXT_PUBLIC_BACKEND_URL={0}', env.UI_BACKEND_URL) || '' }}
+          secrets: ${{ matrix.needs_token && format('gh_token={0}', secrets.AAI_CLI_REPO_ACCESS_TOKEN) || '' }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Smoke test
+        if: matrix.smoke
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/${{ matrix.smoke }}:/smoke-test.sh:ro" \
+            "${{ vars.CLIENT_REGISTRY_URL }}/agent-farm/${{ matrix.name }}:${{ steps.ver.outputs.version }}" \
+            /bin/sh /smoke-test.sh
+
+      - name: Push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: ${{ matrix.name == 'ui' && format('NEXT_PUBLIC_BACKEND_URL={0}', env.UI_BACKEND_URL) || '' }}
+          secrets: ${{ matrix.needs_token && format('gh_token={0}', secrets.AAI_CLI_REPO_ACCESS_TOKEN) || '' }}
+          cache-from: type=gha,scope=${{ matrix.name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,18 +71,22 @@ jobs:
         run: |
           docker build \
             -t '${{ secrets.REGISTRY_URL }}/agentfarm-api:${{ env.API_IMAGE_TAG }}' \
+            -t '${{ secrets.REGISTRY_URL }}/agentfarm-api:latest' \
             -f api/Dockerfile \
             .
           docker push '${{ secrets.REGISTRY_URL }}/agentfarm-api:${{ env.API_IMAGE_TAG }}'
+          docker push '${{ secrets.REGISTRY_URL }}/agentfarm-api:latest'
 
       - name: Build and push UI image
         run: |
           docker build \
             --build-arg NEXT_PUBLIC_BACKEND_URL=https://${{ secrets.API_HOST }} \
             -t '${{ secrets.REGISTRY_URL }}/agentfarm-ui:${{ env.UI_IMAGE_TAG }}' \
+            -t '${{ secrets.REGISTRY_URL }}/agentfarm-ui:latest' \
             -f ui/Dockerfile \
             ui/
           docker push '${{ secrets.REGISTRY_URL }}/agentfarm-ui:${{ env.UI_IMAGE_TAG }}'
+          docker push '${{ secrets.REGISTRY_URL }}/agentfarm-ui:latest'
 
       - name: Build, smoke test, and push hermes-base image
         env:
@@ -92,6 +96,7 @@ jobs:
           docker build \
             --secret id=gh_token,src=/tmp/gh_token \
             -t '${{ secrets.REGISTRY_URL }}/agentfarm-hermes-base:${{ env.HERMES_IMAGE_TAG }}' \
+            -t '${{ secrets.REGISTRY_URL }}/agentfarm-hermes-base:latest' \
             -f hermes-base/Dockerfile \
             hermes-base/
           rm -f /tmp/gh_token
@@ -100,6 +105,7 @@ jobs:
             '${{ secrets.REGISTRY_URL }}/agentfarm-hermes-base:${{ env.HERMES_IMAGE_TAG }}' \
             /bin/sh /smoke-test.sh
           docker push '${{ secrets.REGISTRY_URL }}/agentfarm-hermes-base:${{ env.HERMES_IMAGE_TAG }}'
+          docker push '${{ secrets.REGISTRY_URL }}/agentfarm-hermes-base:latest'
 
       - name: Build, smoke test, and push openclaw-base image
         env:
@@ -109,6 +115,7 @@ jobs:
           docker build \
             --secret id=gh_token,src=/tmp/gh_token \
             -t '${{ secrets.REGISTRY_URL }}/agentfarm-openclaw-base:${{ env.OPENCLAW_IMAGE_TAG }}' \
+            -t '${{ secrets.REGISTRY_URL }}/agentfarm-openclaw-base:latest' \
             -f openclaw-base/Dockerfile \
             openclaw-base/
           rm -f /tmp/gh_token
@@ -117,6 +124,7 @@ jobs:
             '${{ secrets.REGISTRY_URL }}/agentfarm-openclaw-base:${{ env.OPENCLAW_IMAGE_TAG }}' \
             /bin/sh /smoke-test.sh
           docker push '${{ secrets.REGISTRY_URL }}/agentfarm-openclaw-base:${{ env.OPENCLAW_IMAGE_TAG }}'
+          docker push '${{ secrets.REGISTRY_URL }}/agentfarm-openclaw-base:latest'
 
       - name: Set up SSH tunnel to k3s
         run: |
@@ -169,4 +177,4 @@ jobs:
           REGISTRY_SERVER: ${{ secrets.REGISTRY_URL }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-        run: helmfile sync --wait
+        run: helmfile -f helmfile.yaml.gotmpl sync --wait

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -1,0 +1,67 @@
+name: Release Deploy Bundle
+
+# Packages the deployment artifacts (helm charts, k8s/ prerequisites, the
+# helmfile and deploy.sh) plus a ready-to-edit .env.deploy, and attaches the
+# tarball to a GitHub Release. A client downloads it, fills in the credentials,
+# and runs ./deploy.sh. Manual only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag (e.g. v0.15.0)
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  bundle:
+    name: Build and publish deploy bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image versions
+        id: ver
+        run: |
+          chart_version() { grep '^appVersion:' "$1" | awk '{print $2}' | tr -d '"'; }
+          {
+            echo "api=$(chart_version helm/agentfarm-api/Chart.yaml)"
+            echo "ui=$(chart_version helm/agentfarm-ui/Chart.yaml)"
+            echo "hermes=$(tr -d '[:space:]' < hermes-base/VERSION)"
+            echo "openclaw=$(tr -d '[:space:]' < openclaw-base/VERSION)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Assemble bundle
+        run: |
+          set -euo pipefail
+          root=agent-farm-deploy
+          mkdir -p "$root"
+          cp -r helm k8s helmfile.yaml.gotmpl deploy.sh "$root"/
+
+          # Generate .env.deploy from the spec: retarget to the client registry
+          # and pin image tags. Credentials are intentionally left blank for the
+          # client to fill in.
+          sed \
+            -e 's|^REGISTRY_PREFIX=.*|REGISTRY_PREFIX=clients.registry.k8s.aai-labs.com/agent-farm|' \
+            -e 's|^REGISTRY_SERVER=.*|REGISTRY_SERVER=clients.registry.k8s.aai-labs.com|' \
+            -e 's|^API_IMAGE_REPOSITORY=.*|API_IMAGE_REPOSITORY=api|' \
+            -e 's|^UI_IMAGE_REPOSITORY=.*|UI_IMAGE_REPOSITORY=ui|' \
+            -e 's|^HERMES_IMAGE_REPOSITORY=.*|HERMES_IMAGE_REPOSITORY=hermes-base|' \
+            -e 's|^OPENCLAW_IMAGE_REPOSITORY=.*|OPENCLAW_IMAGE_REPOSITORY=openclaw-base|' \
+            -e 's|^API_IMAGE_TAG=.*|API_IMAGE_TAG=${{ steps.ver.outputs.api }}|' \
+            -e 's|^UI_IMAGE_TAG=.*|UI_IMAGE_TAG=${{ steps.ver.outputs.ui }}|' \
+            -e 's|^HERMES_IMAGE_TAG=.*|HERMES_IMAGE_TAG=${{ steps.ver.outputs.hermes }}|' \
+            -e 's|^OPENCLAW_IMAGE_TAG=.*|OPENCLAW_IMAGE_TAG=${{ steps.ver.outputs.openclaw }}|' \
+            .env.deploy.spec > "$root/.env.deploy"
+
+          tar -czf "agent-farm-deploy-${{ inputs.tag }}.tar.gz" "$root"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: ${{ inputs.tag }}
+          files: agent-farm-deploy-${{ inputs.tag }}.tar.gz
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 *.py[cod]
 .env
 .env.test
+.env.deploy
 
 # Log files
 *.log

--- a/api/infrastructure/kubernetes/client.py
+++ b/api/infrastructure/kubernetes/client.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import http.client
 import json
+import os
+import tempfile
 from dataclasses import dataclass, field
 
+import yaml
 from injector import inject, singleton
 from kubernetes import client
 from kubernetes import config as k8s_config
@@ -12,6 +15,8 @@ from kubernetes.stream import portforward as k8s_portforward
 from kubernetes.stream import stream as k8s_stream
 
 from api.core.config import Config
+
+_SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 
 @inject
@@ -22,10 +27,14 @@ class KubernetesClient:
     _apps_v1: client.AppsV1Api = field(init=False)
     _core_v1: client.CoreV1Api = field(init=False)
     _stream_core_v1: client.CoreV1Api = field(init=False)
+    _kubeconfig_path: str | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         if self.config.k8s_kubeconfig_path:
-            k8s_config.load_kube_config(config_file=self.config.k8s_kubeconfig_path)
+            self._kubeconfig_path = self._resolve_kubeconfig(
+                self.config.k8s_kubeconfig_path
+            )
+            k8s_config.load_kube_config(config_file=self._kubeconfig_path)
         else:
             try:
                 k8s_config.load_incluster_config()
@@ -35,11 +44,59 @@ class KubernetesClient:
         self._core_v1 = client.CoreV1Api()
         if self.config.k8s_kubeconfig_path:
             stream_api_client = k8s_config.new_client_from_config(
-                config_file=self.config.k8s_kubeconfig_path
+                config_file=self._kubeconfig_path
             )
         else:
             stream_api_client = client.ApiClient()
         self._stream_core_v1 = client.CoreV1Api(api_client=stream_api_client)
+
+    @staticmethod
+    def _incluster_apiserver() -> str | None:
+        """The in-cluster API server URL when running inside a pod, else None.
+
+        Detection mirrors the official client's load_incluster_config: the kubelet
+        injects KUBERNETES_SERVICE_HOST into every pod and mounts the service
+        account token at a well-known path. Both must be present, so a stray
+        KUBERNETES_SERVICE_HOST exported in a local shell does not trigger a
+        rewrite.
+        """
+        host = os.environ.get("KUBERNETES_SERVICE_HOST")
+        if not host or not os.path.exists(_SERVICE_ACCOUNT_TOKEN_PATH):
+            return None
+        port = os.environ.get("KUBERNETES_SERVICE_PORT_HTTPS") or os.environ.get(
+            "KUBERNETES_SERVICE_PORT", "443"
+        )
+        if ":" in host:  # IPv6 literal
+            host = f"[{host}]"
+        return f"https://{host}:{port}"
+
+    @staticmethod
+    def _resolve_kubeconfig(path: str) -> str:
+        """Returns a kubeconfig path whose server host points at the in-cluster API
+        when running inside a pod. The mounted kubeconfig may carry an external or
+        loopback host (e.g. k3s's 127.0.0.1) that is unreachable from a pod; the
+        cluster CA still validates the in-cluster host, so only the server changes.
+        Off-cluster the original path is returned unchanged.
+        """
+        apiserver = KubernetesClient._incluster_apiserver()
+        if not apiserver:
+            return path
+        with open(path) as f:
+            kubeconfig = yaml.safe_load(f)
+        changed = False
+        for entry in kubeconfig.get("clusters", []):
+            cluster = entry.get("cluster", {})
+            if cluster.get("server") != apiserver:
+                cluster["server"] = apiserver
+                changed = True
+        if not changed:
+            return path
+        patched = os.path.join(
+            tempfile.gettempdir(), "agentfarm-kubeconfig-incluster.yaml"
+        )
+        with open(patched, "w") as f:
+            yaml.safe_dump(kubeconfig, f)
+        return patched
 
     def _create_or_get(self, create_fn, read_fn, namespace: str, manifest):
         try:

--- a/api/tests/unit/test_kubernetes_client.py
+++ b/api/tests/unit/test_kubernetes_client.py
@@ -143,9 +143,7 @@ def test_incluster_apiserver_builds_url(monkeypatch, tmp_path):
     token.write_text("x")
     monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
     monkeypatch.setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
-    monkeypatch.setattr(
-        k8s_client_module, "_SERVICE_ACCOUNT_TOKEN_PATH", str(token)
-    )
+    monkeypatch.setattr(k8s_client_module, "_SERVICE_ACCOUNT_TOKEN_PATH", str(token))
     assert_that(
         KubernetesClient._incluster_apiserver(), equal_to("https://10.0.0.1:443")
     )
@@ -155,7 +153,9 @@ def test_resolve_kubeconfig_unchanged_off_cluster(monkeypatch, tmp_path):
     monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
     kubeconfig = tmp_path / "kubeconfig"
     kubeconfig.write_text(
-        yaml.safe_dump({"clusters": [{"cluster": {"server": "https://127.0.0.1:6443"}}]})
+        yaml.safe_dump(
+            {"clusters": [{"cluster": {"server": "https://127.0.0.1:6443"}}]}
+        )
     )
     assert_that(
         KubernetesClient._resolve_kubeconfig(str(kubeconfig)), equal_to(str(kubeconfig))
@@ -167,13 +167,15 @@ def test_resolve_kubeconfig_rewrites_server_in_cluster(monkeypatch, tmp_path):
     token.write_text("x")
     monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
     monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
-    monkeypatch.setattr(
-        k8s_client_module, "_SERVICE_ACCOUNT_TOKEN_PATH", str(token)
-    )
+    monkeypatch.setattr(k8s_client_module, "_SERVICE_ACCOUNT_TOKEN_PATH", str(token))
     kubeconfig = tmp_path / "kubeconfig"
     kubeconfig.write_text(
         yaml.safe_dump(
-            {"clusters": [{"name": "k3s", "cluster": {"server": "https://127.0.0.1:6443"}}]}
+            {
+                "clusters": [
+                    {"name": "k3s", "cluster": {"server": "https://127.0.0.1:6443"}}
+                ]
+            }
         )
     )
 

--- a/api/tests/unit/test_kubernetes_client.py
+++ b/api/tests/unit/test_kubernetes_client.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
 
+import yaml
 from hamcrest import assert_that, calling, equal_to, none, not_none, raises
 from kubernetes.client import (
     AppsV1Api,
@@ -13,6 +14,7 @@ from kubernetes.client import (
 from kubernetes.client.exceptions import ApiException
 
 from api.core.config import Config
+from api.infrastructure.kubernetes import client as k8s_client_module
 from api.infrastructure.kubernetes.client import KubernetesClient
 
 
@@ -121,3 +123,65 @@ def test_list_services_returns_items():
     items = k8s.list_services("agent-farm", label_selector="agent-id=123")
     assert_that(len(items), equal_to(1))
     assert_that(items[0].metadata.name, equal_to("svc"))
+
+
+def test_incluster_apiserver_none_off_cluster(monkeypatch):
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    assert_that(KubernetesClient._incluster_apiserver(), none())
+
+
+def test_incluster_apiserver_requires_token_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setattr(
+        k8s_client_module, "_SERVICE_ACCOUNT_TOKEN_PATH", str(tmp_path / "missing")
+    )
+    assert_that(KubernetesClient._incluster_apiserver(), none())
+
+
+def test_incluster_apiserver_builds_url(monkeypatch, tmp_path):
+    token = tmp_path / "token"
+    token.write_text("x")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+    monkeypatch.setattr(
+        k8s_client_module, "_SERVICE_ACCOUNT_TOKEN_PATH", str(token)
+    )
+    assert_that(
+        KubernetesClient._incluster_apiserver(), equal_to("https://10.0.0.1:443")
+    )
+
+
+def test_resolve_kubeconfig_unchanged_off_cluster(monkeypatch, tmp_path):
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text(
+        yaml.safe_dump({"clusters": [{"cluster": {"server": "https://127.0.0.1:6443"}}]})
+    )
+    assert_that(
+        KubernetesClient._resolve_kubeconfig(str(kubeconfig)), equal_to(str(kubeconfig))
+    )
+
+
+def test_resolve_kubeconfig_rewrites_server_in_cluster(monkeypatch, tmp_path):
+    token = tmp_path / "token"
+    token.write_text("x")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.setattr(
+        k8s_client_module, "_SERVICE_ACCOUNT_TOKEN_PATH", str(token)
+    )
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text(
+        yaml.safe_dump(
+            {"clusters": [{"name": "k3s", "cluster": {"server": "https://127.0.0.1:6443"}}]}
+        )
+    )
+
+    out = KubernetesClient._resolve_kubeconfig(str(kubeconfig))
+
+    assert out != str(kubeconfig)
+    with open(out) as f:
+        patched = yaml.safe_load(f)
+    assert_that(
+        patched["clusters"][0]["cluster"]["server"], equal_to("https://10.0.0.1:443")
+    )

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Deploy agent-farm to a Kubernetes cluster with helmfile.
+#
+# Reads all configuration from .env.deploy (copy .env.deploy.spec and fill it
+# in). Ships alongside helmfile.yaml.gotmpl and the helm/ charts; run it from that
+# directory. Requires helmfile, helm and the helm-diff plugin.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+ENV_FILE="${ENV_FILE:-.env.deploy}"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "error: $ENV_FILE not found. Copy .env.deploy.spec to $ENV_FILE and fill it in." >&2
+  exit 1
+fi
+
+for bin in helmfile kubectl; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "error: $bin not found on PATH." >&2
+    exit 1
+  fi
+done
+
+# Export everything defined in the env file so helmfile's `env "..."` can read it.
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+: "${KUBECONFIG:?set KUBECONFIG in $ENV_FILE}"
+
+# Kubeconfig the API pod uses to manage agent workloads. Defaults to the same
+# kubeconfig used for this deploy; the API rewrites the server host to the
+# in-cluster API endpoint at runtime, so a loopback host (e.g. k3s's 127.0.0.1)
+# is fine. Override in the env file only to give the pod a different identity.
+: "${POD_KUBECONFIG_B64:=$(base64 "$KUBECONFIG" | tr -d '\n')}"
+export POD_KUBECONFIG_B64
+
+# Cluster prerequisites not owned by any helm release: the agent-farm-user
+# ServiceAccount + RBAC that the API's litellm-key pre-install Job runs as.
+# Idempotent — a no-op on clusters where it already exists.
+kubectl apply -f k8s/agent-farm-user.yaml
+
+helmfile -f helmfile.yaml.gotmpl sync --wait

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -64,8 +64,14 @@ releases:
     set:
       - name: registryPrefix
         value: {{ env "REGISTRY_PREFIX" | default "registry.k8s.aai-labs.com" | quote }}
+      - name: image.repository
+        value: {{ env "API_IMAGE_REPOSITORY" | default "agentfarm-api" | quote }}
+      - name: openclawImage.repository
+        value: {{ env "OPENCLAW_IMAGE_REPOSITORY" | default "agentfarm-openclaw-base" | quote }}
       - name: openclawImage.tag
         value: {{ env "OPENCLAW_IMAGE_TAG" | default "latest" | quote }}
+      - name: hermesImage.repository
+        value: {{ env "HERMES_IMAGE_REPOSITORY" | default "agentfarm-hermes-base" | quote }}
       - name: hermesImage.tag
         value: {{ env "HERMES_IMAGE_TAG" | default "latest" | quote }}
       - name: dbConnectionUrl
@@ -110,6 +116,8 @@ releases:
     set:
       - name: registryPrefix
         value: {{ env "REGISTRY_PREFIX" | default "registry.k8s.aai-labs.com" | quote }}
+      - name: image.repository
+        value: {{ env "UI_IMAGE_REPOSITORY" | default "agentfarm-ui" | quote }}
       - name: ingress.host
         value: {{ env "UI_HOST" | required "UI_HOST is required" | quote }}
     needs:

--- a/k8s/agent-farm-user.yaml
+++ b/k8s/agent-farm-user.yaml
@@ -1,0 +1,42 @@
+# Cluster prerequisite for agent-farm, applied outside helm.
+#
+# The agentfarm-api chart's litellm-key pre-install Job runs as the
+# `agent-farm-user` ServiceAccount: it mints a LiteLLM key and writes it to the
+# `litellm-api-key` Secret via the k8s API, so the SA needs create/update on
+# secrets. This is a cluster-bootstrap identity (not a per-release resource), so
+# it lives here rather than in the chart — applying it is idempotent and a no-op
+# on clusters where it already exists, avoiding helm ownership conflicts.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agent-farm
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-farm-user
+  namespace: agent-farm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-farm-user
+  namespace: agent-farm
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-farm-user
+  namespace: agent-farm
+subjects:
+  - kind: ServiceAccount
+    name: agent-farm-user
+    namespace: agent-farm
+roleRef:
+  kind: Role
+  name: agent-farm-user
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
 ## AF-134: Create a deployment script

  Adds a self-contained way to deploy agent-farm to a Kubernetes cluster, plus the supporting CI to publish images to the client registry and package a release bundle.
  - **`k8s/agent-farm-user.yaml`** — the `agent-farm-user` ServiceAccount + Role/RoleBinding the litellm-key pre-install Job runs as (applied outside helm, idempotent).
  - **`helmfile.yaml` → `helmfile.yaml.gotmpl`** — the `.gotmpl` extension makes helmfile v1 template it. Also parametrizes the image registry/repository (`REGISTRY_PREFIX` + `*_IMAGE_REPOSITORY`) so a deploy can
  retarget registries without editing charts. **Defaults match the internal registry — existing deploys are unchanged.**
  - **In-cluster kubeconfig rewrite** (`api/.../kubernetes/client.py`) — when running inside a pod, rewrites the mounted kubeconfig's server (e.g. k3s's `127.0.0.1`) to the in-cluster API endpoint so it's
  reachable; off-cluster behaviour is unchanged.
  - **`deploy.yml`** — push `:latest` alongside the versioned tag; point sync at the `.gotmpl`.
  - **`client-release.yml`** (manual) — builds & pushes all images to the client registry under `agent-farm/<image>` via a matrix + `docker/*` actions, smoke-testing the base images first.
  - **`release-bundle.yml`** (manual) — packages charts + `k8s/` + helmfile + `deploy.sh` + a pre-filled `.env.deploy` (registry set, credentials blank) and attaches the tarball to a GitHub Release.

  ### Required repo config (for `client-release.yml` only)
  | Name | Type |
  |---|---|
  | `CLIENT_REGISTRY_URL` | Variable |
  | `CLIENT_REGISTRY_USERNAME` | Secret |
  | `CLIENT_REGISTRY_PASSWORD` | Secret |

  `deploy.yml` and `release-bundle.yml` need no new vars/secrets.

  ### Notes
  - No chart files changed → no chart version bumps.
  - The client-registry password is currently the example default; rotate before production (admin-side).

  ### Testing
  - `make check-api` (ruff + ruff format + ty) and the k8s-client unit tests pass.
  - `helmfile -f helmfile.yaml.gotmpl template` renders cleanly for both internal defaults and client overrides.