### PR TITLE
Af 154 integration validation slack bot name

### DIFF
--- a/api/domains/agents/aai_cli_artifacts.py
+++ b/api/domains/agents/aai_cli_artifacts.py
@@ -171,6 +171,44 @@ _PROFILE_BUILDERS: dict[SecretProvider, Callable[..., str]] = {
 }
 
 
+def build_tool_context_md(decrypted: Mapping[SecretProvider, SecretContent]) -> str:
+    """Render a markdown section listing each configured integration's key metadata.
+
+    Injected into tools_md at start_agent time so the agent knows what is already
+    set up and doesn't ask the user for credentials that are already configured.
+    """
+    if not decrypted:
+        return ""
+
+    lines: list[str] = [
+        "\n## Configured Integrations\n",
+        "The following integrations are pre-configured via aai-cli. "
+        "Use aai-cli to interact with them — credentials are already in place. "
+        "Do not ask the user to re-provide them.\n",
+    ]
+    for provider in SecretProvider:
+        content = decrypted.get(provider)
+        if content is None:
+            continue
+        if isinstance(content, GithubContent):
+            lines.append(
+                f"- **GitHub** (`github-work`): {content.owner}/{content.repo}"
+            )
+        elif isinstance(content, JiraContent):
+            lines.append(
+                f"- **Jira** (`jira-work`): {content.site_url} ({content.email})"
+            )
+        elif isinstance(content, ConfluenceContent):
+            lines.append(
+                f"- **Confluence** (`confluence-work`): {content.site_url} ({content.email})"
+            )
+        elif isinstance(content, BitbucketContent):
+            lines.append(
+                f"- **Bitbucket** (`bitbucket-work`): {content.workspace}/{content.repo} ({content.email})"
+            )
+    return "\n".join(lines) + "\n"
+
+
 def build_config_toml(
     decrypted: Mapping[SecretProvider, SecretContent],
     home_dir: str = "/home/node",

--- a/api/domains/agents/models.py
+++ b/api/domains/agents/models.py
@@ -405,6 +405,7 @@ class AgentSlackConfigRead(PydanticBaseModel):
     dm_user_ids: list[str]
     group_policy: SlackGroupPolicy
     dm_policy: SlackDmPolicy
+    bot_display_name: str | None = None  # fetched live from Slack, not persisted
 
 
 class AgentTeamsConfigRead(PydanticBaseModel):

--- a/api/domains/agents/routes.py
+++ b/api/domains/agents/routes.py
@@ -11,6 +11,7 @@ from api.domains.agents.models import (
     AgentRead,
     AgentUpdate,
     PairRequest,
+    SecretProvider,
     get_agent_filter,
 )
 from api.domains.agents.service import AgentService
@@ -149,3 +150,13 @@ def list_slack_users(
     search: Annotated[str | None, Query()] = None,
 ):
     return service.list_slack_users(agent_id, context, search=search)
+
+
+@agents_router.post("/{agent_id}/integrations/{provider}/validate")
+def validate_integration(
+    agent_id: UUID,
+    provider: SecretProvider,
+    context: Annotated[CurrentUserContext, Depends(get_current_user())],
+    service: Annotated[AgentService, Injected(AgentService)],
+):
+    return service.validate_integration(agent_id, provider, context)

--- a/api/domains/agents/scripts/openclaw/init-openclaw.js
+++ b/api/domains/agents/scripts/openclaw/init-openclaw.js
@@ -86,10 +86,18 @@ function restorePreinstalledMsteamsPlugin(overlay) {
   console.log('[init-openclaw] Restored preinstalled Microsoft Teams npm plugin');
 }
 
+// Files the agent writes runtime state to — never overwrite on restart.
+const AGENT_OWNED_FILES = new Set(['USER.md']);
+
 fs.mkdirSync(WORKSPACE_DIR, { recursive: true });
 for (const file of fs.readdirSync(TEMPLATE_DIR)) {
   if (!file.endsWith('.md')) continue;
-  fs.copyFileSync(path.join(TEMPLATE_DIR, file), path.join(WORKSPACE_DIR, file));
+  const dest = path.join(WORKSPACE_DIR, file);
+  if (AGENT_OWNED_FILES.has(file) && fs.existsSync(dest)) {
+    console.log(`[init-openclaw] Preserving workspace/${file} (agent-owned)`);
+    continue;
+  }
+  fs.copyFileSync(path.join(TEMPLATE_DIR, file), dest);
   console.log(`[init-openclaw] Copied workspace/${file}`);
 }
 

--- a/api/domains/agents/service.py
+++ b/api/domains/agents/service.py
@@ -1,10 +1,10 @@
 import concurrent.futures
-import datetime
+import datetime as dt
 import fnmatch
 import logging
 import secrets
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -17,6 +17,7 @@ from api.domains.agents.aai_cli_artifacts import (
     build_config_toml,
     build_env,
     build_setup_sh,
+    build_tool_context_md,
     provider_to_secret_name_map,
 )
 from api.domains.agents.aai_cli_skills import build_skills_manifest_from_zips
@@ -65,6 +66,7 @@ from api.domains.agents.models import (
 from api.domains.agents.error_messages import friendly_k8s_error, friendly_pod_reason
 from api.domains.agents.repository import AgentRepository
 from api.domains.auth.models import CurrentUserContext
+from api.domains.auth.token_service import SlackConfigTokenService
 from api.domains.templates.models import TemplateRead
 from api.domains.templates.renderer import render_template
 from api.domains.templates.repository import TemplateRepository
@@ -73,12 +75,23 @@ from api.domains.tool_calls.sync_service import ToolCallSyncService
 from api.infrastructure.crypto import decrypt_token, encrypt_token
 from api.infrastructure.kubernetes.client import KubernetesClient
 from api.infrastructure.shared.models import PaginatedItems, Pagination
+from api.infrastructure.integration_validators import (
+    validate_bitbucket,
+    validate_confluence,
+    validate_github,
+    validate_jira,
+)
 from api.infrastructure.slack.client import (
     SlackClient,
     SlackFetchError,
 )
+from api.infrastructure.slack.config_token import update_slack_app_name
 
 logger = logging.getLogger(__name__)
+
+# Bot display name cache: agent_id → (name, fetched_at). TTL = 60 s.
+_bot_name_cache: dict[str, tuple[str, dt.datetime]] = {}
+_BOT_NAME_TTL = dt.timedelta(seconds=60)
 
 # Pre-stop conversation/tool-call flush is best-effort and must not block the
 # teardown. We run both syncs in a shared pool and wait at most this long;
@@ -110,6 +123,13 @@ _TEAMS_CONFIG_FIELDS = frozenset(
 
 
 _OPENROUTER_MODEL_PREFIX = "litellm/openrouter/"
+
+_VALIDATORS: dict[SecretProvider, Any] = {
+    SecretProvider.GITHUB: validate_github,
+    SecretProvider.JIRA: validate_jira,
+    SecretProvider.CONFLUENCE: validate_confluence,
+    SecretProvider.BITBUCKET: validate_bitbucket,
+}
 
 
 def _allowlist_patterns(allowlist: str) -> list[str]:
@@ -155,6 +175,7 @@ class AgentService:
     conversation_sync_service: ConversationSyncService
     sync_service: ToolCallSyncService
     skill_repository: SkillRepository
+    slack_token_service: SlackConfigTokenService
 
     def _org_id(self, context: CurrentUserContext) -> UUID:
         return context.require_current_user_organization().organization_id
@@ -280,6 +301,10 @@ class AgentService:
         slack_config_read = (
             AgentSlackConfigRead.model_validate(slack_config) if slack_config else None
         )
+        if slack_config_read and slack_config:
+            slack_config_read.bot_display_name = self._get_bot_display_name(
+                str(agent.id), slack_config
+            )
         teams_config_read = (
             AgentTeamsConfigRead.model_validate(teams_config) if teams_config else None
         )
@@ -327,6 +352,26 @@ class AgentService:
         return self._build_agent_read(
             agent, slack_config, teams_config, secrets, skills
         )
+
+    def _get_bot_display_name(
+        self, agent_id: str, slack_config: AgentSlackConfig
+    ) -> str | None:
+        now = dt.datetime.now(dt.timezone.utc)
+        cached = _bot_name_cache.get(agent_id)
+        if cached and now - cached[1] < _BOT_NAME_TTL:
+            return cached[0]
+        try:
+            bot_token = decrypt_token(
+                slack_config.bot_token_encrypted,
+                self.config.agent_token_encryption_key,
+            )
+            info = SlackClient(bot_token).get_bot_info()
+            name = info.get("bot_name") or None
+            if name:
+                _bot_name_cache[agent_id] = (name, now)
+            return name
+        except Exception:
+            return cached[0] if cached else None
 
     def create_agent(self, data: AgentCreate, context: CurrentUserContext) -> AgentRead:
         org_id = self._org_id(context)
@@ -428,18 +473,17 @@ class AgentService:
         secrets: list[AgentSecret] = []
         for item in data.secrets:
             content = validate_content(item.provider, item.content)
-            secrets.append(
-                self.repository.save_secret(
-                    AgentSecret(
-                        agent_id=agent.id,
-                        provider=item.provider,
-                        secret_name=PROVIDER_DISPLAY_NAMES[item.provider],
-                        content=encrypt_content(
-                            content, self.config.agent_token_encryption_key
-                        ),
-                    )
+            saved = self.repository.save_secret(
+                AgentSecret(
+                    agent_id=agent.id,
+                    provider=item.provider,
+                    secret_name=PROVIDER_DISPLAY_NAMES[item.provider],
+                    content=encrypt_content(
+                        content, self.config.agent_token_encryption_key
+                    ),
                 )
             )
+            secrets.append(saved)
 
         # Resolve and validate skills before any DB writes.
         skills_to_assign = self._resolve_skills(data.skill_ids, data.secrets, org_id)
@@ -558,6 +602,8 @@ class AgentService:
 
         if "name" in updated:
             agent.name = updated["name"]
+            if agent.platform == AgentPlatform.SLACK:
+                self._try_rename_slack_app(agent, updated["name"], context)
 
         if "model" in updated:
             self._ensure_model_allowed(updated["model"])
@@ -583,6 +629,7 @@ class AgentService:
                         updated["slack_bot_token"],
                         self.config.agent_token_encryption_key,
                     )
+                    _bot_name_cache.pop(str(agent.id), None)
                 if "slack_app_token" in updated:
                     slack_config.app_token_encrypted = encrypt_token(
                         updated["slack_app_token"],
@@ -843,8 +890,10 @@ class AgentService:
         skills_json = (
             build_skills_manifest_from_zips(agent_skills) if agent_skills else None
         )
-        tools_md = rendered.tools_md + self._build_skill_pointers(
-            [s for _, s in agent_skills]
+        tools_md = (
+            rendered.tools_md
+            + self._build_skill_pointers([s for _, s in agent_skills])
+            + build_tool_context_md(decrypted)
         )
 
         if agent.agent_type == AgentType.HERMES:
@@ -970,7 +1019,7 @@ class AgentService:
         self.k8s.delete_secret(name, ns)
         self.k8s.delete_config_map(name, ns)
 
-        agent.deleted_at = datetime.datetime.now(datetime.timezone.utc)
+        agent.deleted_at = dt.datetime.now(dt.timezone.utc)
         self.repository.save(agent)
 
         if agent.litellm_key_encrypted:
@@ -1130,6 +1179,63 @@ class AgentService:
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Could not load Slack users right now. Please try again.",
             ) from exc
+
+    def validate_integration(
+        self, agent_id: UUID, provider: SecretProvider, context: CurrentUserContext
+    ) -> dict:
+        """Validate an existing secret on demand. Never persists — returns result directly."""
+        org_id = self._org_id(context)
+        self._get_active_or_404(agent_id, org_id)
+        secret = self.repository.get_secret(agent_id, provider)
+        if secret is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No {provider.value} credential configured for this agent",
+            )
+        validator = _VALIDATORS.get(provider)
+        if validator is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"No validator available for {provider.value}",
+            )
+        content = decrypt_content(
+            provider, secret.content, self.config.agent_token_encryption_key
+        )
+        result = validator(content)  # type: ignore[arg-type]
+        if result.valid and result.missing_scopes:
+            validation_status = "warning"
+        elif result.valid:
+            validation_status = "valid"
+        else:
+            validation_status = "invalid"
+        return {
+            "validation_status": validation_status,
+            "validation_identity": result.identity,
+            "validation_error": result.error,
+            "missing_scopes": result.missing_scopes,
+        }
+
+    def _try_rename_slack_app(
+        self, agent: Agent, new_name: str, context: CurrentUserContext
+    ) -> None:
+        """Best-effort: rename the Slack app to match the new agent name. Never raises."""
+        try:
+            bot_token = self._get_bot_token(agent)
+            bot_info = SlackClient(bot_token).get_bot_info()
+            app_id = bot_info.get("app_id", "")
+            if not app_id:
+                return
+            access_token = self.slack_token_service.get_usable_access_token(
+                context.user.id
+            )
+            update_slack_app_name(access_token, app_id, new_name)
+        except Exception:
+            logger.warning(
+                "Could not rename Slack app for agent %s to %r",
+                agent.id,
+                new_name,
+                exc_info=True,
+            )
 
     def _get_bot_token(self, agent: Agent) -> str:
         slack_config = self.repository.get_slack_config(agent.id)

--- a/api/domains/templates/predefined/code_reviewer.py
+++ b/api/domains/templates/predefined/code_reviewer.py
@@ -140,6 +140,8 @@ USER_MD = """\
 
 If `Setup complete: yes` is absent below, setup has not run yet — it will trigger automatically on the next Slack message.
 
+Code host, repository, base URLs, and integration credentials are in TOOLS.md — do not duplicate them here.
+
 ## Operator
 
 The person who deployed me, summons me from DMs, and tunes my behaviour. They get the most direct voice — terse, no filler. They are the only one allowed to change my scope or pause me for a PR.
@@ -149,16 +151,12 @@ The person who deployed me, summons me from DMs, and tunes my behaviour. They ge
 - **Setup complete:**
 - **Team lead name:**
 - **Team lead Slack handle:**
-- **Primary code host (bitbucket or github):**
-- **Repo owner (GitHub org or Bitbucket workspace, e.g. `my-org`):**
-- **Repository (bare repo name for --repo flag, e.g. `my-repo`):**
 - **Primary review Slack channel (e.g. `#code-reviews`):**
 
 ### Optional
 
-- **Jira base URL (e.g. `https://myorg.atlassian.net`):** 
-- **Jira project key(s) (e.g. `AUTH`, `PLAT`):** 
-- **Confluence space key(s) (e.g. `ENG`, `TEAM`):** 
+- **Jira project key(s) (e.g. `AUTH`, `PLAT`):**
+- **Confluence space key(s) (e.g. `ENG`, `TEAM`):**
 - **Pronouns:**
 - **Timezone:**
 - **Notes:**
@@ -213,7 +211,7 @@ External integrations are driven exclusively by `aai-cli`. **This is the only su
 
 - **Slack**: built-in integration configured during agent setup. No `aai-cli` skill — see the Slack section below for posture.
 
-Read the primary code host and configured integrations from USER.md before running any aai-cli command.
+Read configured integrations from the `## Configured Integrations` section of TOOLS.md before running any aai-cli command. Code host, repo owner, repository name, and base URLs are all there — do not ask the user for them.
 
 ## aai-cli Policy
 
@@ -226,21 +224,21 @@ Read the primary code host and configured integrations from USER.md before runni
 
 ## Bitbucket
 
-Used when USER.md lists Bitbucket as the primary code host. Read `./skills/aai-cli/bitbucket_skill/bitbucket_skill.md` before running any command — it documents every available operation and the ones that are forbidden.
+Used when Bitbucket is listed in TOOLS.md Configured Integrations. Read `./skills/aai-cli/bitbucket_skill/bitbucket_skill.md` before running any command — it documents every available operation and the ones that are forbidden.
 
 - **Posture**: read PRs, diffs, source files, and pipeline logs freely. The only write allowed is posting PR comments.
 - **Never** call approve, decline, merge, or any branch-write command — these are explicitly forbidden in the skill file.
 
 ## GitHub
 
-Used when USER.md lists GitHub as the primary code host. Read `./skills/aai-cli/github_skill/github_skill.md` before running any command.
+Used when GitHub is listed in TOOLS.md Configured Integrations. Read `./skills/aai-cli/github_skill/github_skill.md` before running any command.
 
 - **Posture**: read PRs, diffs, source files, and Actions logs freely. The only writes allowed are PR comments and review comments.
 - **Never** pass `--event APPROVE` to any review command.
 
 ## Jira
 
-Used when USER.md has a Jira base URL configured. Read `./skills/aai-cli/jira_skill/jira_skill.md` before running any command.
+Used when Jira is listed in TOOLS.md Configured Integrations. Read `./skills/aai-cli/jira_skill/jira_skill.md` before running any command.
 
 - **Posture**: read-only. Fetch the linked ticket and acceptance criteria; never transition, comment on, or modify a ticket.
 - Use bounded queries only — never fish blindly across all projects.
@@ -254,7 +252,7 @@ Used when USER.md has a Jira base URL configured. Read `./skills/aai-cli/jira_sk
 
 ## Confluence
 
-Used when USER.md has a Confluence space key configured. Read `./skills/aai-cli/confluence_skill/confluence_skill.md` before running any command.
+Used when Confluence is listed in TOOLS.md Configured Integrations. Read `./skills/aai-cli/confluence_skill/confluence_skill.md` before running any command.
 
 - **Posture**: read-only. Search for codified style guides or review checklists to cite when firing a style finding. Never create or edit pages.
 
@@ -289,20 +287,34 @@ The Setup Flow below runs exactly once, on first contact. BOOT.md step 1 gates e
 
 ## Setup Flow
 
-### Step 1: Introduce yourself and ask
+### Step 1: Read TOOLS.md
 
-Send a single Slack message to whoever initiated the conversation:
+Read the `## Configured Integrations` section of TOOLS.md. Identify:
+- **Code host**: GitHub (`github-work`) or Bitbucket (`bitbucket-work`) — required to review PRs.
+- **Jira** (`jira-work`) — optional, enables ticket context.
+- **Confluence** (`confluence-work`) — optional, enables style guide lookups.
 
-> Hi, I'm {{ agent_display_name }}, your Code Review agent. Before I start reviewing PRs, I need a few details about your setup — I'll only ask once.
+### Step 2: Introduce yourself and ask
+
+If no code host integration is listed, send this message and stop — do not proceed until the user confirms one has been added:
+
+> Hi, I'm {{ agent_display_name }}, your Code Review agent. Before I can start, I need a code host integration (GitHub or Bitbucket) to be set up. Please add one under this agent's **Integrations** tab in the dashboard, then send me a message to continue.
+
+Otherwise send a single Slack message:
+
+> Hi, I'm {{ agent_display_name }}, your Code Review agent. My integrations are configured — I just need a couple of details before I start reviewing PRs.
 >
 > 1. **Your name and Slack handle** — as the team lead who oversees code reviews *(required)*
-> 2. **Primary code host** — Bitbucket or GitHub? *(required)*
-> 3. **Repo owner** — the GitHub org or Bitbucket workspace (e.g. `my-org`) *(required)*
-> 4. **Repository** — the bare repository name (e.g. `my-repo`) *(required)*
-> 5. **Primary review Slack channel** — where I should post open PR lists and review summaries (e.g. `#code-reviews`) *(required)*
-> 6. **Jira base URL** — e.g. `https://myorg.atlassian.net` *(optional)*
-> 7. **Jira project key(s)** — e.g. `AUTH`, `PLAT` *(optional)*
-> 8. **Confluence space key(s)** — e.g. `ENG` *(optional — for style guide lookups)*
+> 2. **Primary review Slack channel** — where I should post open PR lists and review summaries (e.g. `#code-reviews`) *(required)*
+
+If Jira is configured, add:
+> 3. **Jira project key(s)** — e.g. `AUTH`, `PLAT` *(required to use your Jira integration)*
+
+If Confluence is configured, add:
+> 4. **Confluence space key(s)** — e.g. `ENG` *(required to use your Confluence integration)*
+
+If Jira or Confluence is not yet configured but the user might want it, close with:
+> *To add Jira or Confluence, go to this agent's **Integrations** tab in the dashboard.*
 
 Wait for a response. If a required item is missing from their reply, ask for it specifically before continuing.
 
@@ -313,13 +325,11 @@ Once the required info is provided, update USER.md:
 - `Setup complete:` → `yes` (write this first — it is the gate that prevents setup from re-triggering)
 - Name → `Team lead name:`
 - Slack handle → `Team lead Slack handle:`
-- Code host → `Primary code host:`
-- Repo owner → `Repo owner:`
-- Repository → `Repository:`
 - Review channel → `Primary review Slack channel:`
-- Jira base URL → `Jira base URL:` (if provided)
 - Jira key(s) → `Jira project key(s):` (if provided)
 - Confluence key(s) → `Confluence space key(s):` (if provided)
+
+Code host, repo owner, repository, and base URLs are already in TOOLS.md — do not write them to USER.md.
 
 ### Step 3: Create the cron job
 
@@ -497,7 +507,7 @@ If you were summoned over the gateway (`send-message`) rather than Slack, skip t
 
 ## 5. Pull the inputs
 
-For a PR review, read the relevant skill files first (see TOOLS.md Skill Index). All API calls go through `aai-cli` — never call the code host API directly.
+Get `<repo_owner>`, `<repository>`, and `<host>` from the `## Configured Integrations` section of TOOLS.md (e.g. GitHub lists `owner/repo`; Bitbucket lists `workspace/repo`). Read the relevant skill files first (see TOOLS.md Skill Index). All API calls go through `aai-cli` — never call the code host API directly.
 
 1. Fetch PR metadata: read the PR sub-skill (`bitbucket_pr_skill.md` or GitHub equivalent), then run `prs get <PR_NUMBER> --repo <repository> --owner <repo_owner> --profile <host>-work` for title, description, author, source/target branch, and linked tickets.
 2. Fetch the unified diff: `prs diff <PR_NUMBER> --repo <repository> --owner <repo_owner> --output local/logs/pr-N.diff --profile <host>-work` for large PRs.

--- a/api/domains/templates/predefined/scrum_master.py
+++ b/api/domains/templates/predefined/scrum_master.py
@@ -65,6 +65,8 @@ USER_MD = """\
 Learn about the team you are helping. Update this file when stable context is useful for future Scrum-Master work.
 If the Required fields below are empty, the Setup Flow in AGENTS.md has not run yet — it will trigger automatically on the next Slack message.
 
+Integration credentials, base URLs, and repository details are in TOOLS.md — do not duplicate them here.
+
 ## Team Context
 
 ### Required
@@ -73,11 +75,6 @@ If the Required fields below are empty, the Setup Flow in AGENTS.md has not run 
 - **Team lead Slack handle:**
 - **Jira project key(s):**
 - **Confluence space key(s):**
-
-### Optional (populate if the team uses these)
-
-- **GitHub organizations/repositories:**
-- **Bitbucket workspaces/projects/repositories:**
 
 ### Additional Context
 
@@ -181,16 +178,31 @@ Your job is to keep delivery work visible, organized, and moving without becomin
 
 Run this flow when USER.md Required fields are missing — on first Slack message or whenever the context has been reset. **DO NOT** mention this flow once setup is complete; it is only for initial onboarding.
 
-### Step 1: Introduce yourself and ask
+### Step 1: Read TOOLS.md
 
-Send a single Slack message to whoever initiated the conversation:
+Read the `## Configured Integrations` section of TOOLS.md. Identify which integrations are available:
+- **Jira** (`jira-work`) — required for sprint and ticket work.
+- **Confluence** (`confluence-work`) — required for docs and meeting notes.
+- **GitHub** (`github-work`) or **Bitbucket** (`bitbucket-work`) — optional, for PR and branch context.
 
-> Hi, I'm {{ agent_display_name }}, your Scrum Master agent. Before I can start work, I need a few details about your team — I'll only ask once.
+### Step 2: Introduce yourself and ask
+
+If Jira is not configured, send this message and stop:
+
+> Hi, I'm {{ agent_display_name }}, your Scrum Master agent. Before I can start, I need a Jira integration to be set up. Please add it under this agent's **Integrations** tab in the dashboard, then send me a message to continue.
+
+Otherwise send a single Slack message:
+
+> Hi, I'm {{ agent_display_name }}, your Scrum Master agent. My integrations are configured — I just need a couple of details about your team before I start.
 >
 > 1. **Your name and Slack handle** — so I know who to loop in for approvals *(required)*
 > 2. **Jira project key(s)** — e.g. `AUTH`, `PLAT` *(required)*
-> 3. **Confluence space key(s)** — e.g. `ENG`, `TEAM` *(required)*
-> 4. **GitHub org/repo or Bitbucket workspace/repo** — e.g. `myorg/myrepo` *(optional)*
+
+If Confluence is configured, add:
+> 3. **Confluence space key(s)** — e.g. `ENG`, `TEAM` *(required to use your Confluence integration)*
+
+If Confluence is not yet configured, close with:
+> *To add Confluence or a code host integration, go to this agent's **Integrations** tab in the dashboard.*
 
 Wait for a response. If a required item is missing from their reply, ask for it specifically before continuing.
 
@@ -201,8 +213,9 @@ Once the required info is provided, update USER.md:
 - Name → `Team lead:`
 - Slack handle → `Team lead Slack handle:`
 - Jira key(s) → `Jira project key(s):`
-- Confluence key(s) → `Confluence space key(s):`
-- Repo(s) → `GitHub organizations/repositories:` or `Bitbucket workspaces/projects/repositories:` as appropriate
+- Confluence key(s) → `Confluence space key(s):` (if provided)
+
+Integration credentials, base URLs, and repository details are already in TOOLS.md — do not write them to USER.md.
 
 ### Step 3: Create cron jobs
 

--- a/api/infrastructure/integration_validators/__init__.py
+++ b/api/infrastructure/integration_validators/__init__.py
@@ -1,0 +1,13 @@
+from api.infrastructure.integration_validators.bitbucket import validate_bitbucket
+from api.infrastructure.integration_validators.confluence import validate_confluence
+from api.infrastructure.integration_validators.github import validate_github
+from api.infrastructure.integration_validators.jira import validate_jira
+from api.infrastructure.integration_validators.result import IntegrationValidationResult
+
+__all__ = [
+    "IntegrationValidationResult",
+    "validate_bitbucket",
+    "validate_confluence",
+    "validate_github",
+    "validate_jira",
+]

--- a/api/infrastructure/integration_validators/bitbucket.py
+++ b/api/infrastructure/integration_validators/bitbucket.py
@@ -1,0 +1,218 @@
+import httpx
+
+from api.domains.agents.models import BitbucketContent
+from api.infrastructure.integration_validators.result import IntegrationValidationResult
+
+_TIMEOUT = 10
+_USER_URL = "https://api.bitbucket.org/2.0/user"
+
+
+def validate_bitbucket(content: BitbucketContent) -> IntegrationValidationResult:
+    try:
+        bearer_resp = httpx.get(
+            _USER_URL,
+            headers={"Authorization": f"Bearer {content.api_token}"},
+            timeout=_TIMEOUT,
+        )
+    except Exception as exc:
+        return IntegrationValidationResult(
+            valid=False, error=f"Could not reach Bitbucket: {exc}"
+        )
+
+    # Bearer returning 401 can mean several things:
+    # - App password / personal API token → needs Basic auth (email:token)
+    # - HTTP access token (workspace/repo scoped) → needs Bearer on a resource endpoint
+    # Try Basic auth first; if that also fails, fall back to the scoped token path.
+    if bearer_resp.status_code == 401:
+        try:
+            basic_resp = httpx.get(
+                _USER_URL,
+                auth=(content.email, content.api_token),
+                timeout=_TIMEOUT,
+            )
+        except Exception as exc:
+            return IntegrationValidationResult(
+                valid=False, error=f"Could not reach Bitbucket: {exc}"
+            )
+        if basic_resp.status_code != 401:
+            return _handle_user_response(basic_resp, content)
+        # Basic auth also failed — treat as a workspace/repo HTTP access token.
+        return _validate_scoped_token(content)
+
+    return _handle_user_response(bearer_resp, content)
+
+
+def _handle_user_response(
+    resp: httpx.Response, content: BitbucketContent
+) -> IntegrationValidationResult:
+    if resp.status_code == 401:
+        return IntegrationValidationResult(
+            valid=False, error="Invalid API token or credentials"
+        )
+    if resp.status_code == 403:
+        # The token is authenticated but /user requires read:user:bitbucket scope.
+        # A scoped API token without that scope still has valid repo/PR access.
+        # Use the granted scopes from the 403 body to determine what's missing.
+        return _handle_user_scope_denied(resp, content)
+    if resp.status_code != 200:
+        return IntegrationValidationResult(
+            valid=False,
+            error=f"Bitbucket returned unexpected status {resp.status_code}",
+        )
+
+    data = resp.json()
+    display_name = data.get("display_name", "")
+    nickname = data.get("nickname", "")
+    identity = f"{display_name} (@{nickname})" if nickname else display_name
+
+    missing = _check_repo_read_scope(content, bearer=True)
+    return IntegrationValidationResult(
+        valid=True, identity=identity, missing_scopes=missing
+    )
+
+
+def _handle_user_scope_denied(
+    resp: httpx.Response, content: BitbucketContent
+) -> IntegrationValidationResult:
+    """Token is valid but missing read:user — check granted scopes for repo/PR access."""
+    detail = resp.json().get("error", {}).get("detail", {})
+    granted = set(detail.get("granted", []))
+
+    missing: list[str] = []
+    if (
+        "read:repository:bitbucket" not in granted
+        and "write:repository:bitbucket" not in granted
+    ):
+        missing.append("Repositories (read) scope missing")
+    if (
+        "read:pullrequest:bitbucket" not in granted
+        and "write:pullrequest:bitbucket" not in granted
+    ):
+        missing.append(
+            "Pull requests: Read + Write — needed to read PRs and post review comments"
+        )
+
+    identity = f"workspace: {content.workspace}" if content.workspace else content.email
+    return IntegrationValidationResult(
+        valid=True, identity=identity, missing_scopes=missing
+    )
+
+
+def _validate_scoped_token(content: BitbucketContent) -> IntegrationValidationResult:
+    """Validate a workspace/repository access token by probing workspace endpoints."""
+    if not content.workspace:
+        return IntegrationValidationResult(
+            valid=False,
+            error="Workspace access token requires a workspace to be configured",
+        )
+
+    headers = {"Authorization": f"Bearer {content.api_token}"}
+    try:
+        resp = httpx.get(
+            f"https://api.bitbucket.org/2.0/repositories/{content.workspace}",
+            headers=headers,
+            timeout=_TIMEOUT,
+        )
+    except Exception as exc:
+        return IntegrationValidationResult(
+            valid=False, error=f"Could not reach Bitbucket: {exc}"
+        )
+
+    if resp.status_code == 401:
+        return IntegrationValidationResult(
+            valid=False, error="Invalid or expired access token"
+        )
+    if resp.status_code == 403 and content.repo:
+        # Repository-scoped tokens can't list the workspace — probe the specific
+        # repo instead before concluding the scope is missing.
+        return _validate_repo_scoped_token(content, headers)
+    if resp.status_code == 403:
+        return IntegrationValidationResult(
+            valid=False,
+            error="Access token is missing the Repositories (read) scope",
+        )
+    if resp.status_code not in (200, 404):
+        return IntegrationValidationResult(
+            valid=False,
+            error=f"Bitbucket returned unexpected status {resp.status_code}",
+        )
+
+    identity = f"workspace: {content.workspace}"
+    missing = _check_pr_scope(content, headers)
+    return IntegrationValidationResult(
+        valid=True, identity=identity, missing_scopes=missing
+    )
+
+
+def _validate_repo_scoped_token(
+    content: BitbucketContent, headers: dict[str, str]
+) -> IntegrationValidationResult:
+    """Probe the specific repo for tokens scoped below workspace level."""
+    try:
+        resp = httpx.get(
+            f"https://api.bitbucket.org/2.0/repositories/{content.workspace}/{content.repo}",
+            headers=headers,
+            timeout=_TIMEOUT,
+        )
+    except Exception as exc:
+        return IntegrationValidationResult(
+            valid=False, error=f"Could not reach Bitbucket: {exc}"
+        )
+
+    if resp.status_code == 401:
+        return IntegrationValidationResult(
+            valid=False, error="Invalid or expired access token"
+        )
+    if resp.status_code == 403:
+        return IntegrationValidationResult(
+            valid=False,
+            error="Access token is missing the Repositories (read) scope",
+        )
+    if resp.status_code not in (200, 404):
+        return IntegrationValidationResult(
+            valid=False,
+            error=f"Bitbucket returned unexpected status {resp.status_code}",
+        )
+
+    identity = f"{content.workspace}/{content.repo}"
+    missing = _check_pr_scope(content, headers)
+    return IntegrationValidationResult(
+        valid=True, identity=identity, missing_scopes=missing
+    )
+
+
+def _check_repo_read_scope(
+    content: BitbucketContent, *, bearer: bool = True
+) -> list[str]:
+    if not content.workspace:
+        return []
+    headers = {"Authorization": f"Bearer {content.api_token}"} if bearer else {}
+    try:
+        resp = httpx.get(
+            f"https://api.bitbucket.org/2.0/repositories/{content.workspace}",
+            headers=headers,
+            timeout=_TIMEOUT,
+        )
+        if resp.status_code == 403:
+            return ["Repositories (read) scope missing"]
+    except Exception:
+        pass
+    return []
+
+
+def _check_pr_scope(content: BitbucketContent, headers: dict[str, str]) -> list[str]:
+    if not content.workspace or not content.repo:
+        return []
+    try:
+        resp = httpx.get(
+            f"https://api.bitbucket.org/2.0/repositories/{content.workspace}/{content.repo}/pullrequests",
+            headers=headers,
+            timeout=_TIMEOUT,
+        )
+        if resp.status_code == 403:
+            return [
+                "Pull requests: Read + Write — needed to read PRs and post review comments"
+            ]
+    except Exception:
+        pass
+    return []

--- a/api/infrastructure/integration_validators/confluence.py
+++ b/api/infrastructure/integration_validators/confluence.py
@@ -1,0 +1,47 @@
+import httpx
+
+from api.domains.agents.models import ConfluenceContent
+from api.infrastructure.integration_validators.result import IntegrationValidationResult
+
+_TIMEOUT = 10
+
+
+def validate_confluence(content: ConfluenceContent) -> IntegrationValidationResult:
+    base = content.site_url.rstrip("/")
+    auth = (content.email, content.api_token)
+    try:
+        resp = httpx.get(
+            f"{base}/wiki/rest/api/user/current",
+            auth=auth,
+            timeout=_TIMEOUT,
+        )
+    except Exception as exc:
+        return IntegrationValidationResult(
+            valid=False, error=f"Could not reach Confluence: {exc}"
+        )
+
+    if resp.status_code == 401:
+        return IntegrationValidationResult(
+            valid=False, error="Invalid email or API token"
+        )
+    if resp.status_code == 403:
+        return IntegrationValidationResult(
+            valid=False, error="Account does not have Confluence product access"
+        )
+    if resp.status_code != 200:
+        return IntegrationValidationResult(
+            valid=False,
+            error=f"Confluence returned unexpected status {resp.status_code}",
+        )
+
+    data = resp.json()
+    if data.get("type") == "anonymous":
+        return IntegrationValidationResult(
+            valid=False, error="Authentication was not accepted"
+        )
+
+    display_name = data.get("displayName", "")
+    email = data.get("email", content.email)
+    identity = f"{display_name} ({email})" if email else display_name
+
+    return IntegrationValidationResult(valid=True, identity=identity)

--- a/api/infrastructure/integration_validators/github.py
+++ b/api/infrastructure/integration_validators/github.py
@@ -1,0 +1,95 @@
+import httpx
+
+from api.domains.agents.models import GithubContent
+from api.infrastructure.integration_validators.result import IntegrationValidationResult
+
+_TIMEOUT = 10
+
+
+def validate_github(content: GithubContent) -> IntegrationValidationResult:
+    headers = {
+        "Authorization": f"Bearer {content.token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        resp = httpx.get(
+            "https://api.github.com/user", headers=headers, timeout=_TIMEOUT
+        )
+    except Exception as exc:
+        return IntegrationValidationResult(
+            valid=False, error=f"Could not reach GitHub: {exc}"
+        )
+
+    if resp.status_code == 401:
+        return IntegrationValidationResult(
+            valid=False, error="Token is invalid or expired"
+        )
+    if resp.status_code != 200:
+        return IntegrationValidationResult(
+            valid=False, error=f"GitHub returned unexpected status {resp.status_code}"
+        )
+
+    identity = resp.json().get("login", "")
+    scopes_header = resp.headers.get("X-OAuth-Scopes", "")
+
+    missing: list[str] = []
+
+    if scopes_header:
+        # Classic PAT — inspect declared scopes.
+        scopes = {s.strip() for s in scopes_header.split(",") if s.strip()}
+        if "repo" not in scopes and "public_repo" not in scopes:
+            missing.append("repo (or public_repo for public-only repositories)")
+        if "read:user" not in scopes and "user" not in scopes:
+            missing.append("read:user")
+        if "read:org" not in scopes and "admin:org" not in scopes:
+            missing.append("read:org (recommended for organisation repositories)")
+    else:
+        # Fine-grained PAT — probe the configured repo directly.
+        missing = _check_fine_grained_repo_access(content, headers)
+
+    return IntegrationValidationResult(
+        valid=True, identity=identity, missing_scopes=missing
+    )
+
+
+def _check_fine_grained_repo_access(
+    content: GithubContent, headers: dict[str, str]
+) -> list[str]:
+    if not content.owner or not content.repo:
+        return []
+    missing: list[str] = []
+
+    # Check repository contents access.
+    try:
+        resp = httpx.get(
+            f"https://api.github.com/repos/{content.owner}/{content.repo}",
+            headers=headers,
+            timeout=_TIMEOUT,
+        )
+        if resp.status_code == 403:
+            accepted = resp.headers.get("X-Accepted-GitHub-Permissions", "")
+            detail = "contents=read" if not accepted else accepted
+            missing.append(f"Repository access — needs: {detail}")
+        elif resp.status_code == 404:
+            missing.append(
+                "Repository contents read access (or repository does not exist)"
+            )
+    except Exception:
+        pass
+
+    # Check pull request read access.
+    try:
+        pr_resp = httpx.get(
+            f"https://api.github.com/repos/{content.owner}/{content.repo}/pulls",
+            headers=headers,
+            timeout=_TIMEOUT,
+        )
+        if pr_resp.status_code == 403:
+            missing.append(
+                "Pull requests: Read + Write — needed to list PRs and post review comments"
+            )
+    except Exception:
+        pass
+
+    return missing

--- a/api/infrastructure/integration_validators/jira.py
+++ b/api/infrastructure/integration_validators/jira.py
@@ -1,0 +1,46 @@
+import httpx
+
+from api.domains.agents.models import JiraContent
+from api.infrastructure.integration_validators.result import IntegrationValidationResult
+
+_TIMEOUT = 10
+
+
+def validate_jira(content: JiraContent) -> IntegrationValidationResult:
+    base = content.site_url.rstrip("/")
+    auth = (content.email, content.api_token)
+    try:
+        resp = httpx.get(
+            f"{base}/rest/api/3/myself",
+            auth=auth,
+            timeout=_TIMEOUT,
+        )
+    except Exception as exc:
+        return IntegrationValidationResult(
+            valid=False, error=f"Could not reach Jira: {exc}"
+        )
+
+    if resp.status_code == 401:
+        return IntegrationValidationResult(
+            valid=False, error="Invalid email or API token"
+        )
+    if resp.status_code == 403:
+        return IntegrationValidationResult(
+            valid=False, error="Account does not have Jira product access"
+        )
+    if resp.status_code != 200:
+        return IntegrationValidationResult(
+            valid=False, error=f"Jira returned unexpected status {resp.status_code}"
+        )
+
+    data = resp.json()
+    if not data.get("active"):
+        return IntegrationValidationResult(
+            valid=False, error="Jira account is inactive"
+        )
+
+    display_name = data.get("displayName", "")
+    email = data.get("emailAddress", "")
+    identity = f"{display_name} ({email})" if email else display_name
+
+    return IntegrationValidationResult(valid=True, identity=identity)

--- a/api/infrastructure/integration_validators/result.py
+++ b/api/infrastructure/integration_validators/result.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class IntegrationValidationResult:
+    valid: bool
+    identity: str | None = None
+    missing_scopes: list[str] = field(default_factory=list)
+    error: str | None = None

--- a/api/infrastructure/slack/client.py
+++ b/api/infrastructure/slack/client.py
@@ -116,6 +116,20 @@ class SlackClient:
         code = body.get("error", "unknown_error")
         return False, error_map.get(code, f"Slack {label} token error: {code}")
 
+    def get_bot_info(self) -> dict:
+        """Returns app_id, bot username, and team from auth.test. Empty dict on failure."""
+        try:
+            body = self._post("auth.test", {})
+            if not body.get("ok"):
+                return {}
+            return {
+                "app_id": body.get("app_id", ""),
+                "bot_name": body.get("user", ""),
+                "team": body.get("team", ""),
+            }
+        except Exception:
+            return {}
+
     # --- channel actions ---------------------------------------------------
 
     def join_channel(self, channel_id: str) -> bool:

--- a/api/infrastructure/slack/config_token.py
+++ b/api/infrastructure/slack/config_token.py
@@ -51,7 +51,7 @@ def validate_config_access_token(token: str) -> None:
 
     manifest = {
         "display_information": {
-            "name": "Agent Farm Validation",
+            "name": "Agent Barn Validation",
             "description": "Temporary manifest validation",
         },
         "features": {
@@ -61,7 +61,7 @@ def validate_config_access_token(token: str) -> None:
                 "messages_tab_read_only_enabled": False,
             },
             "bot_user": {
-                "display_name": "Agent Farm Validation",
+                "display_name": "Agent Barn Validation",
                 "always_online": False,
             },
         },
@@ -131,6 +131,29 @@ def rotate_refresh_token(refresh_token: str) -> tuple[str, str]:
 
     validate_config_access_token(access_token)
     return access_token, new_refresh_token
+
+
+def update_slack_app_name(access_token: str, app_id: str, new_name: str) -> bool:
+    """Best-effort rename of a Slack app's display name. Returns True on success, never raises."""
+    try:
+        export_body = _post_form(
+            access_token, "apps.manifest.export", {"app_id": app_id}
+        )
+        if not export_body.get("ok"):
+            return False
+        manifest = export_body.get("manifest", {})
+        manifest.setdefault("display_information", {})["name"] = new_name
+        manifest.setdefault("features", {}).setdefault("bot_user", {})[
+            "display_name"
+        ] = new_name
+        update_body = _post_form(
+            access_token,
+            "apps.manifest.update",
+            {"app_id": app_id, "manifest": json.dumps(manifest)},
+        )
+        return bool(update_body.get("ok"))
+    except Exception:
+        return False
 
 
 def create_slack_app(access_token: str, manifest: dict) -> str:

--- a/api/tests/unit/test_aai_cli_artifacts.py
+++ b/api/tests/unit/test_aai_cli_artifacts.py
@@ -3,6 +3,7 @@ from api.domains.agents.aai_cli_artifacts import (
     build_config_toml,
     build_env,
     build_setup_sh,
+    build_tool_context_md,
     env_var_for,
     token_attr,
 )
@@ -26,6 +27,15 @@ _CONFLUENCE = validate_content(
         "site_url": "https://x.atlassian.net",
         "email": "a@b.com",
         "api_token": "conf_tok",
+    },
+)
+_BITBUCKET = validate_content(
+    SecretProvider.BITBUCKET,
+    {
+        "workspace": "my-workspace",
+        "repo": "my-repo",
+        "email": "a@b.com",
+        "api_token": "bb_tok",
     },
 )
 _GMAIL = validate_content(
@@ -132,3 +142,68 @@ def test_setup_sh_hermes_home_dir_exports_opt_data():
 def test_setup_sh_default_home_dir_is_home_node():
     setup = build_setup_sh([])
     assert "export HOME=/home/node" in setup
+
+
+# --- build_tool_context_md ----------------------------------------------------
+
+
+def test_tool_context_md_empty_when_no_secrets():
+    assert build_tool_context_md({}) == ""
+
+
+def test_tool_context_md_lists_github_profile():
+    md = build_tool_context_md({SecretProvider.GITHUB: _GITHUB})
+    assert "github-work" in md
+    assert "aai-labs/agent-farm" in md
+    assert "Do not ask the user to re-provide" in md
+
+
+def test_tool_context_md_lists_jira_profile():
+    md = build_tool_context_md({SecretProvider.JIRA: _JIRA})
+    assert "jira-work" in md
+    assert "https://x.atlassian.net" in md
+    assert "a@b.com" in md
+
+
+def test_tool_context_md_lists_confluence_profile():
+    md = build_tool_context_md({SecretProvider.CONFLUENCE: _CONFLUENCE})
+    assert "confluence-work" in md
+    assert "https://x.atlassian.net" in md
+
+
+def test_tool_context_md_lists_bitbucket_profile():
+    md = build_tool_context_md({SecretProvider.BITBUCKET: _BITBUCKET})
+    assert "bitbucket-work" in md
+    assert "my-workspace/my-repo" in md
+
+
+def test_tool_context_md_omits_non_aai_cli_providers():
+    md = build_tool_context_md({SecretProvider.GMAIL: _GMAIL})
+    # Gmail is not listed as a named profile in the context block
+    assert "gmail-work" not in md
+
+
+def test_tool_context_md_never_leaks_tokens():
+    md = build_tool_context_md(
+        {
+            SecretProvider.GITHUB: _GITHUB,
+            SecretProvider.JIRA: _JIRA,
+            SecretProvider.BITBUCKET: _BITBUCKET,
+        }
+    )
+    assert "ghp_tok" not in md
+    assert "jira_tok" not in md
+    assert "bb_tok" not in md
+
+
+def test_tool_context_md_lists_multiple_providers():
+    md = build_tool_context_md(
+        {
+            SecretProvider.GITHUB: _GITHUB,
+            SecretProvider.JIRA: _JIRA,
+            SecretProvider.CONFLUENCE: _CONFLUENCE,
+        }
+    )
+    assert "github-work" in md
+    assert "jira-work" in md
+    assert "confluence-work" in md

--- a/api/tests/unit/test_integration_validators.py
+++ b/api/tests/unit/test_integration_validators.py
@@ -1,0 +1,561 @@
+"""
+TDD: failing tests for api/infrastructure/integration_validators/*.
+Run these first — they should all fail until the implementation exists.
+"""
+
+from unittest.mock import patch
+
+import httpx
+
+from api.domains.agents.models import (
+    BitbucketContent,
+    ConfluenceContent,
+    GithubContent,
+    JiraContent,
+)
+from api.infrastructure.integration_validators.bitbucket import validate_bitbucket
+from api.infrastructure.integration_validators.confluence import validate_confluence
+from api.infrastructure.integration_validators.github import validate_github
+from api.infrastructure.integration_validators.jira import validate_jira
+from api.infrastructure.integration_validators.result import IntegrationValidationResult
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+_REQUEST = httpx.Request("GET", "https://example.com")
+
+
+def _resp(
+    body: dict | list, *, status: int = 200, headers: dict | None = None
+) -> httpx.Response:
+    return httpx.Response(status, json=body, headers=headers or {}, request=_REQUEST)
+
+
+def _connect_error() -> httpx.ConnectError:
+    return httpx.ConnectError("connection refused", request=_REQUEST)
+
+
+_GH = GithubContent(token="ghp_test", owner="acme", repo="backend", org="acme-org")
+_JIRA = JiraContent(
+    site_url="https://acme.atlassian.net", email="alice@acme.com", api_token="jira-tok"
+)
+_CONFLUENCE = ConfluenceContent(
+    site_url="https://acme.atlassian.net", email="alice@acme.com", api_token="conf-tok"
+)
+_BB = BitbucketContent(
+    workspace="acme", repo="backend", email="alice@acme.com", api_token="bb-tok"
+)
+
+# ── IntegrationValidationResult ───────────────────────────────────────────────
+
+
+def test_result_valid_defaults():
+    r = IntegrationValidationResult(valid=True)
+    assert r.valid is True
+    assert r.identity is None
+    assert r.missing_scopes == []
+    assert r.error is None
+
+
+def test_result_invalid_with_error():
+    r = IntegrationValidationResult(valid=False, error="bad token")
+    assert r.valid is False
+    assert r.error == "bad token"
+
+
+def test_result_warning_has_missing_scopes():
+    r = IntegrationValidationResult(valid=True, missing_scopes=["read:org"])
+    assert r.missing_scopes == ["read:org"]
+
+
+# ── GitHub ────────────────────────────────────────────────────────────────────
+
+_GH_MOD = "api.infrastructure.integration_validators.github.httpx.get"
+
+
+def test_github_classic_pat_all_scopes_present():
+    user_resp = _resp(
+        {"login": "alice"}, headers={"X-OAuth-Scopes": "repo, read:user, read:org"}
+    )
+    with patch(_GH_MOD, return_value=user_resp):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert result.identity == "alice"
+    assert result.missing_scopes == []
+    assert result.error is None
+
+
+def test_github_classic_pat_missing_repo_scope():
+    user_resp = _resp(
+        {"login": "alice"}, headers={"X-OAuth-Scopes": "read:user, read:org"}
+    )
+    with patch(_GH_MOD, return_value=user_resp):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert any("repo" in s.lower() for s in result.missing_scopes)
+
+
+def test_github_classic_pat_missing_read_user_scope():
+    user_resp = _resp({"login": "alice"}, headers={"X-OAuth-Scopes": "repo, read:org"})
+    with patch(_GH_MOD, return_value=user_resp):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert any("read:user" in s for s in result.missing_scopes)
+
+
+def test_github_classic_pat_missing_read_org_scope():
+    user_resp = _resp({"login": "alice"}, headers={"X-OAuth-Scopes": "repo, read:user"})
+    with patch(_GH_MOD, return_value=user_resp):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert any("read:org" in s for s in result.missing_scopes)
+
+
+def test_github_classic_pat_broad_user_scope_covers_read_user():
+    """'user' scope is a superset of read:user — should not warn."""
+    user_resp = _resp(
+        {"login": "alice"}, headers={"X-OAuth-Scopes": "repo, user, read:org"}
+    )
+    with patch(_GH_MOD, return_value=user_resp):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert not any("read:user" in s for s in result.missing_scopes)
+
+
+def test_github_fine_grained_pat_repo_accessible():
+    """Fine-grained PATs have no X-OAuth-Scopes header; test the repo and pulls endpoints."""
+    user_resp = _resp({"login": "alice"})  # no X-OAuth-Scopes header
+    repo_resp = _resp({"full_name": "acme/backend"})
+    pulls_resp = _resp([])
+
+    with patch(_GH_MOD, side_effect=[user_resp, repo_resp, pulls_resp]):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert result.missing_scopes == []
+
+
+def test_github_fine_grained_pat_repo_access_denied():
+    user_resp = _resp({"login": "alice"})
+    repo_resp = _resp(
+        {"message": "forbidden"},
+        status=403,
+        headers={"X-Accepted-GitHub-Permissions": "contents=read"},
+    )
+    pulls_resp = _resp([])
+
+    with patch(_GH_MOD, side_effect=[user_resp, repo_resp, pulls_resp]):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert len(result.missing_scopes) > 0
+    assert any("contents=read" in s for s in result.missing_scopes)
+
+
+def test_github_fine_grained_pat_pr_access_denied():
+    user_resp = _resp({"login": "alice"})
+    repo_resp = _resp({"full_name": "acme/backend"})
+    pulls_resp = _resp({"message": "forbidden"}, status=403)
+
+    with patch(_GH_MOD, side_effect=[user_resp, repo_resp, pulls_resp]):
+        result = validate_github(_GH)
+
+    assert result.valid is True
+    assert any("Pull requests" in s for s in result.missing_scopes)
+
+
+def test_github_invalid_token_401():
+    with patch(_GH_MOD, return_value=_resp({}, status=401)):
+        result = validate_github(_GH)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "invalid" in result.error.lower() or "expired" in result.error.lower()
+
+
+def test_github_unexpected_status_returns_error():
+    with patch(_GH_MOD, return_value=_resp({}, status=500)):
+        result = validate_github(_GH)
+
+    assert result.valid is False
+    assert "500" in (result.error or "")
+
+
+def test_github_network_error_returns_error():
+    with patch(_GH_MOD, side_effect=_connect_error()):
+        result = validate_github(_GH)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "github" in result.error.lower()
+
+
+# ── Jira ──────────────────────────────────────────────────────────────────────
+
+_JIRA_MOD = "api.infrastructure.integration_validators.jira.httpx.get"
+
+
+def test_jira_valid_credentials_returns_identity():
+    body = {
+        "displayName": "Alice",
+        "emailAddress": "alice@acme.com",
+        "active": True,
+        "accountType": "atlassian",
+    }
+    with patch(_JIRA_MOD, return_value=_resp(body)):
+        result = validate_jira(_JIRA)
+
+    assert result.valid is True
+    assert "Alice" in (result.identity or "")
+    assert "alice@acme.com" in (result.identity or "")
+    assert result.error is None
+
+
+def test_jira_invalid_credentials_401():
+    with patch(_JIRA_MOD, return_value=_resp({}, status=401)):
+        result = validate_jira(_JIRA)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "invalid" in result.error.lower() or "token" in result.error.lower()
+
+
+def test_jira_no_product_access_403():
+    with patch(_JIRA_MOD, return_value=_resp({}, status=403)):
+        result = validate_jira(_JIRA)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "access" in result.error.lower() or "jira" in result.error.lower()
+
+
+def test_jira_inactive_account_returns_error():
+    body = {"displayName": "Alice", "emailAddress": "alice@acme.com", "active": False}
+    with patch(_JIRA_MOD, return_value=_resp(body)):
+        result = validate_jira(_JIRA)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "inactive" in result.error.lower()
+
+
+def test_jira_unexpected_status_returns_error():
+    with patch(_JIRA_MOD, return_value=_resp({}, status=502)):
+        result = validate_jira(_JIRA)
+
+    assert result.valid is False
+    assert "502" in (result.error or "")
+
+
+def test_jira_network_error_returns_error():
+    with patch(_JIRA_MOD, side_effect=_connect_error()):
+        result = validate_jira(_JIRA)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "jira" in result.error.lower()
+
+
+# ── Confluence ────────────────────────────────────────────────────────────────
+
+_CONF_MOD = "api.infrastructure.integration_validators.confluence.httpx.get"
+
+
+def test_confluence_valid_credentials_returns_identity():
+    body = {"type": "known", "displayName": "Alice", "email": "alice@acme.com"}
+    with patch(_CONF_MOD, return_value=_resp(body)):
+        result = validate_confluence(_CONFLUENCE)
+
+    assert result.valid is True
+    assert "Alice" in (result.identity or "")
+    assert "alice@acme.com" in (result.identity or "")
+    assert result.error is None
+
+
+def test_confluence_anonymous_type_means_auth_rejected():
+    body = {"type": "anonymous"}
+    with patch(_CONF_MOD, return_value=_resp(body)):
+        result = validate_confluence(_CONFLUENCE)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "auth" in result.error.lower() or "anonymous" in result.error.lower()
+
+
+def test_confluence_invalid_credentials_401():
+    with patch(_CONF_MOD, return_value=_resp({}, status=401)):
+        result = validate_confluence(_CONFLUENCE)
+
+    assert result.valid is False
+    assert result.error is not None
+
+
+def test_confluence_no_product_access_403():
+    with patch(_CONF_MOD, return_value=_resp({}, status=403)):
+        result = validate_confluence(_CONFLUENCE)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "confluence" in result.error.lower() or "access" in result.error.lower()
+
+
+def test_confluence_unexpected_status_returns_error():
+    with patch(_CONF_MOD, return_value=_resp({}, status=503)):
+        result = validate_confluence(_CONFLUENCE)
+
+    assert result.valid is False
+    assert "503" in (result.error or "")
+
+
+def test_confluence_network_error_returns_error():
+    with patch(_CONF_MOD, side_effect=_connect_error()):
+        result = validate_confluence(_CONFLUENCE)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "confluence" in result.error.lower()
+
+
+# ── Bitbucket ─────────────────────────────────────────────────────────────────
+
+_BB_MOD = "api.infrastructure.integration_validators.bitbucket.httpx.get"
+
+_BB_USER_BODY = {
+    "type": "user",
+    "display_name": "Alice",
+    "nickname": "alice",
+    "account_id": "abc123",
+    "uuid": "{uuid}",
+}
+
+
+def test_bitbucket_valid_bearer_token_returns_identity():
+    user_resp = _resp(_BB_USER_BODY)
+    repo_resp = _resp({"values": []})  # workspace repos accessible
+
+    with patch(_BB_MOD, side_effect=[user_resp, repo_resp]):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert "Alice" in (result.identity or "")
+    assert result.missing_scopes == []
+    assert result.error is None
+
+
+def test_bitbucket_falls_back_to_basic_auth_when_bearer_fails():
+    """If Bearer auth returns 401, retry with Basic auth (email:api_token)."""
+    bearer_fail = _resp({}, status=401)
+    basic_ok = _resp(_BB_USER_BODY)
+    repo_resp = _resp({"values": []})
+
+    with patch(_BB_MOD, side_effect=[bearer_fail, basic_ok, repo_resp]) as mock_get:
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    # Second call must use Basic auth — verify the call was made differently
+    calls = mock_get.call_args_list
+    assert len(calls) >= 2
+
+
+def test_bitbucket_missing_repo_read_scope_warns():
+    """Workspace repo list returns 403 → missing_scopes includes repository read."""
+    user_resp = _resp(_BB_USER_BODY)
+    repo_403 = _resp({"type": "error"}, status=403)
+
+    with patch(_BB_MOD, side_effect=[user_resp, repo_403]):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert len(result.missing_scopes) > 0
+    assert any("repositor" in s.lower() for s in result.missing_scopes)
+
+
+def test_bitbucket_invalid_token_both_auth_methods_fail():
+    with patch(_BB_MOD, return_value=_resp({}, status=401)):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "invalid" in result.error.lower() or "token" in result.error.lower()
+
+
+def test_bitbucket_403_on_user_with_repo_scopes_is_valid():
+    """Token missing read:user but has repo scopes — treat as valid with no missing scopes."""
+    body = {
+        "type": "error",
+        "error": {
+            "message": "Your credentials lack one or more required privilege scopes.",
+            "detail": {
+                "required": ["read:user:bitbucket"],
+                "granted": [
+                    "read:repository:bitbucket",
+                    "read:pullrequest:bitbucket",
+                    "write:pullrequest:bitbucket",
+                ],
+            },
+        },
+    }
+    with patch(_BB_MOD, return_value=_resp(body, status=403)):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert result.missing_scopes == []
+
+
+def test_bitbucket_403_on_user_missing_repo_scope():
+    """Token missing read:user AND repo scopes — report missing repo scope."""
+    body = {
+        "type": "error",
+        "error": {
+            "message": "Your credentials lack one or more required privilege scopes.",
+            "detail": {"required": ["read:user:bitbucket"], "granted": []},
+        },
+    }
+    with patch(_BB_MOD, return_value=_resp(body, status=403)):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert any("repositor" in s.lower() for s in result.missing_scopes)
+
+
+def test_bitbucket_network_error_returns_error():
+    with patch(_BB_MOD, side_effect=_connect_error()):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "bitbucket" in result.error.lower()
+
+
+def test_bitbucket_identity_includes_nickname():
+    user_resp = _resp({**_BB_USER_BODY, "nickname": "al"})
+    repo_resp = _resp({"values": []})
+
+    with patch(_BB_MOD, side_effect=[user_resp, repo_resp]):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert "al" in (result.identity or "")
+
+
+def test_bitbucket_no_workspace_skips_repo_check():
+    """If workspace is empty, skip the repo read scope probe."""
+    no_workspace = BitbucketContent(
+        workspace="", repo="be", email="a@b.com", api_token="t"
+    )
+    user_resp = _resp(_BB_USER_BODY)
+
+    with patch(_BB_MOD, side_effect=[user_resp]) as mock_get:
+        result = validate_bitbucket(no_workspace)
+
+    assert result.valid is True
+    assert result.missing_scopes == []
+    assert mock_get.call_count == 1  # only /user, no /repositories probe
+
+
+_BB_SCOPED_401 = {
+    "type": "error",
+    "error": {
+        "message": "Token is invalid, expired, or not supported for this endpoint."
+    },
+}
+
+
+_BASIC_401 = _resp({}, status=401)
+
+
+def test_bitbucket_scoped_token_valid():
+    """Workspace HTTP access token: Bearer fails, Basic fails, Bearer on /repositories works."""
+    bearer_fail = _resp(_BB_SCOPED_401, status=401)
+    repos_ok = _resp({"values": []})
+    pr_ok = _resp({"values": []})
+
+    with patch(_BB_MOD, side_effect=[bearer_fail, _BASIC_401, repos_ok, pr_ok]):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert result.missing_scopes == []
+
+
+def test_bitbucket_scoped_token_missing_repo_scope():
+    """Scoped token with no read scope: workspace listing AND specific repo both denied."""
+    bearer_fail = _resp(_BB_SCOPED_401, status=401)
+    workspace_403 = _resp({"type": "error"}, status=403)
+    repo_403 = _resp({"type": "error"}, status=403)
+
+    with patch(_BB_MOD, side_effect=[bearer_fail, _BASIC_401, workspace_403, repo_403]):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is False
+    assert result.error is not None
+    assert "repositor" in result.error.lower()
+
+
+def test_bitbucket_scoped_token_missing_pr_scope():
+    """Workspace access token: repos OK but pull requests scope missing."""
+    bearer_fail = _resp(_BB_SCOPED_401, status=401)
+    repos_ok = _resp({"values": []})
+    pr_403 = _resp({"type": "error"}, status=403)
+
+    with patch(_BB_MOD, side_effect=[bearer_fail, _BASIC_401, repos_ok, pr_403]):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert any("pull request" in s.lower() for s in result.missing_scopes)
+
+
+def test_bitbucket_repo_scoped_token_valid():
+    """Repository-scoped token: workspace listing returns 403, specific repo probe succeeds."""
+    bearer_fail = _resp(_BB_SCOPED_401, status=401)
+    workspace_403 = _resp({"type": "error"}, status=403)
+    repo_ok = _resp({"full_name": "acme/backend"})
+    pr_ok = _resp({"values": []})
+
+    with patch(
+        _BB_MOD, side_effect=[bearer_fail, _BASIC_401, workspace_403, repo_ok, pr_ok]
+    ):
+        result = validate_bitbucket(_BB)
+
+    assert result.valid is True
+    assert result.missing_scopes == []
+
+
+def test_bitbucket_scoped_token_no_workspace_returns_error():
+    """Scoped token with no workspace configured cannot be validated."""
+    no_workspace = BitbucketContent(
+        workspace="", repo="be", email="a@b.com", api_token="t"
+    )
+    bearer_fail = _resp(_BB_SCOPED_401, status=401)
+
+    with patch(_BB_MOD, side_effect=[bearer_fail]):
+        result = validate_bitbucket(no_workspace)
+
+    assert result.valid is False
+    assert result.error is not None
+
+
+def test_github_fine_grained_no_owner_skips_repo_probe():
+    """Fine-grained PAT with no owner/repo configured — skip the repo probe."""
+    no_repo = GithubContent(token="ghp_fine", owner="", repo="", org="")
+    user_resp = _resp({"login": "alice"})  # no X-OAuth-Scopes
+
+    with patch(_GH_MOD, side_effect=[user_resp]) as mock_get:
+        result = validate_github(no_repo)
+
+    assert result.valid is True
+    assert result.missing_scopes == []
+    assert mock_get.call_count == 1  # only /user, no /repos probe
+
+
+def test_confluence_identity_falls_back_to_content_email_when_absent():
+    """Confluence may omit 'email' from the response body; fall back to the stored email."""
+    body = {"type": "known", "displayName": "Alice"}  # no email field
+    with patch(_CONF_MOD, return_value=_resp(body)):
+        result = validate_confluence(_CONFLUENCE)
+
+    assert result.valid is True
+    assert _CONFLUENCE.email in (result.identity or "")

--- a/api/tests/unit/test_openrouter_client.py
+++ b/api/tests/unit/test_openrouter_client.py
@@ -136,6 +136,7 @@ def _service(openrouter, allowlist="", default_model=""):
         config=config,
         conversation_sync_service=MagicMock(),
         sync_service=MagicMock(),
+        slack_token_service=MagicMock(),
     )
 
 

--- a/api/tests/unit/test_slack_client.py
+++ b/api/tests/unit/test_slack_client.py
@@ -240,3 +240,37 @@ def test_validate_bot_token_unreachable_slack_returns_error():
 
     assert ok is False
     assert "Could not reach Slack" in message
+
+
+# --- get_bot_info ----------------------------------------------------------
+
+
+def test_get_bot_info_returns_fields_on_success():
+    payload = {
+        "ok": True,
+        "app_id": "ATEST123",
+        "user": "my-bot",
+        "team": "My Workspace",
+    }
+    with patch("httpx.request", _mock_httpx([_resp(payload)])):
+        info = SlackClient("xoxb-token").get_bot_info()
+
+    assert info == {"app_id": "ATEST123", "bot_name": "my-bot", "team": "My Workspace"}
+
+
+def test_get_bot_info_returns_empty_dict_on_non_ok():
+    with patch(
+        "httpx.request", _mock_httpx([_resp({"ok": False, "error": "invalid_auth"})])
+    ):
+        info = SlackClient("xoxb-token").get_bot_info()
+
+    assert info == {}
+
+
+def test_get_bot_info_returns_empty_dict_on_network_error():
+    errors = [httpx.ConnectError("down", request=_REQUEST)] * 3
+    with patch("httpx.request", _mock_httpx(errors)):
+        with patch("api.infrastructure.slack.transport.time.sleep"):
+            info = SlackClient("xoxb-token").get_bot_info()
+
+    assert info == {}

--- a/api/tests/unit/test_slack_config_token.py
+++ b/api/tests/unit/test_slack_config_token.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from api.infrastructure.slack.config_token import (
     create_slack_app,
     rotate_refresh_token,
+    update_slack_app_name,
     validate_config_access_token,
 )
 
@@ -89,3 +90,47 @@ def test_create_slack_app_invalid_auth(mock_rj):
 
     assert exc.value.status_code == 400
     assert "invalid or expired" in exc.value.detail
+
+
+# --- update_slack_app_name --------------------------------------------------
+
+
+def test_update_slack_app_name_success():
+    _TRANSPORT_CT = "api.infrastructure.slack.config_token.request_json"
+    export_resp = {
+        "ok": True,
+        "manifest": {
+            "display_information": {"name": "Old Name"},
+            "features": {"bot_user": {"display_name": "Old Name"}},
+        },
+    }
+    update_resp = {"ok": True}
+    with patch(_TRANSPORT_CT, side_effect=[export_resp, update_resp]) as mock_rj:
+        result = update_slack_app_name("token", "AAPP123", "New Name")
+
+    assert result is True
+    # Second call (update) sends form-encoded body; decode then parse the manifest field.
+    import json
+    import urllib.parse
+
+    update_call_args = mock_rj.call_args_list[1]
+    form = urllib.parse.parse_qs(update_call_args[1]["content"].decode())
+    sent_manifest = json.loads(form["manifest"][0])
+    assert sent_manifest["display_information"]["name"] == "New Name"
+    assert sent_manifest["features"]["bot_user"]["display_name"] == "New Name"
+
+
+def test_update_slack_app_name_export_failure_returns_false():
+    _TRANSPORT_CT = "api.infrastructure.slack.config_token.request_json"
+    with patch(_TRANSPORT_CT, return_value={"ok": False, "error": "not_found"}):
+        result = update_slack_app_name("token", "AAPP123", "New Name")
+
+    assert result is False
+
+
+def test_update_slack_app_name_network_error_returns_false():
+    _TRANSPORT_CT = "api.infrastructure.slack.config_token.request_json"
+    with patch(_TRANSPORT_CT, side_effect=Exception("connection refused")):
+        result = update_slack_app_name("token", "AAPP123", "New Name")
+
+    assert result is False

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.19.0"

--- a/helm/agentfarm-ui/Chart.yaml
+++ b/helm/agentfarm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: agentfarm-ui
 description: Next.js frontend for agent-farm
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.18.0"

--- a/ui/src/app/dashboard/settings/page.tsx
+++ b/ui/src/app/dashboard/settings/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { PROVIDERS } from "@/features/agents/data";
 import { TemplatesPanel } from "@/features/agents/components/templates-panel";
 import { SkillsPanel } from "@/features/skills/components/skills-panel";
-import { PlusIcon, LockIcon, ShieldIcon, EyeIcon, ServerIcon, SearchIcon } from "@/components/icons";
+import { PlusIcon, LockIcon, EyeIcon, ServerIcon, SearchIcon } from "@/components/icons";
 
 type SectionKey =
   | "general"
@@ -357,7 +357,7 @@ function InfraPanel() {
     <div>
       <Hint>
         <ServerIcon style={{ flexShrink: 0, marginTop: 1 }} />
-        Agent Farm runs on your Kubernetes. You usually don&apos;t need to touch this — but here it is.
+        Agent Barn runs on your Kubernetes. You usually don&apos;t need to touch this — but here it is.
       </Hint>
       <Field label="Cluster" hint="Where agents are scheduled.">
         <div className="flex items-center gap-2.5">

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -48,7 +48,7 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
-/* ─── Agent Farm design tokens (warm cream palette) ──────────────── */
+/* ─── Agent Barn design tokens (warm cream palette) ──────────────── */
 :root {
   /* shadcn vars — mapped to warm palette */
   --card: #ffffff;
@@ -84,7 +84,7 @@
   --background: #fbfaf8;
   --foreground: #1a1815;
 
-  /* Agent Farm custom tokens */
+  /* Agent Barn custom tokens */
   --bg:            #fbfaf8;
   --bg-elev:       #ffffff;
   --bg-soft:       #f4f2ee;
@@ -133,7 +133,7 @@
   }
 }
 
-/* ─── Agent Farm utility classes ─────────────────────────────────── */
+/* ─── Agent Barn utility classes ─────────────────────────────────── */
 
 .af-card {
   background: var(--bg-elev);

--- a/ui/src/app/icon.svg
+++ b/ui/src/app/icon.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="7" fill="#1a1714"/>
-  <text x="16" y="22" font-family="monospace" font-size="13" font-weight="600" fill="#fbfaf8" text-anchor="middle">AF</text>
+  <path d="M16,3 L26.5,9.5 L27.5,29 L4.5,29 L5.5,9.5 Z" stroke="#fbfaf8" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round" fill="none"/>
+  <path d="M16,10.5 L22.5,14.5 L22.5,23 L9.5,23 L9.5,14.5 Z" stroke="#fbfaf8" stroke-width="1.6" stroke-linejoin="round" fill="none"/>
+  <circle cx="16" cy="18.5" r="2" fill="#fbfaf8"/>
 </svg>

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -21,7 +21,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Agent Farm",
+  title: "Agent Barn",
   description: "Manage your AI agent workforce.",
 };
 

--- a/ui/src/auth/components/login-form.tsx
+++ b/ui/src/auth/components/login-form.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 
 import { useAuthActions } from "@/auth/hooks/use-auth-actions";
 import { LoginFormData, LoginSchema } from "@/auth/schemas";
+import { LogoMark } from "@/components/logo-mark";
 
 export function LoginForm() {
   const router = useRouter();
@@ -49,11 +50,8 @@ export function LoginForm() {
         style={{ background: "var(--bg-elev)", border: "1px solid var(--line)", boxShadow: "var(--shadow)" }}
       >
         <div className="text-center mb-7">
-          <div
-            className="w-9 h-9 rounded-xl grid place-items-center font-mono text-[14px] font-semibold text-white mx-auto mb-4"
-            style={{ background: "var(--ink)" }}
-          >
-            AF
+          <div className="flex justify-center mb-4">
+            <LogoMark size={36} />
           </div>
           <h1 className="text-[22px] font-semibold tracking-tight m-0 mb-1" style={{ color: "var(--ink)" }}>
             Welcome back

--- a/ui/src/components/logo-mark.tsx
+++ b/ui/src/components/logo-mark.tsx
@@ -1,0 +1,53 @@
+interface LogoMarkProps {
+  size?: number;
+}
+
+export function LogoMark({ size = 26 }: LogoMarkProps) {
+  const radius = size <= 28 ? 8 : 12;
+  const padding = Math.round(size * 0.14);
+
+  return (
+    <div
+      aria-label="Agent Barn"
+      style={{
+        width: size,
+        height: size,
+        background: "var(--ink)",
+        borderRadius: radius,
+        display: "grid",
+        placeItems: "center",
+        flexShrink: 0,
+        padding,
+        boxSizing: "border-box",
+      }}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 100 100"
+        aria-hidden
+        style={{ display: "block", width: "100%", height: "100%" }}
+      >
+        {/* Outer barn silhouette */}
+        <path
+          d="M50,8 L82,28 L88,88 L12,88 L18,28 Z"
+          stroke="var(--bg)"
+          strokeWidth="8"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          fill="none"
+        />
+        {/* Inner house outline */}
+        <path
+          d="M50,30 L70,43 L70,70 L30,70 L30,43 Z"
+          stroke="var(--bg)"
+          strokeWidth="6"
+          strokeLinejoin="round"
+          fill="none"
+        />
+        {/* Door / focal dot */}
+        <circle cx="50" cy="55" r="6" fill="var(--bg)" />
+      </svg>
+    </div>
+  );
+}

--- a/ui/src/components/top-nav.tsx
+++ b/ui/src/components/top-nav.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useCurrentUser } from "@/auth/providers/user-context-provider";
 import { useLogout } from "@/auth/hooks/use-logout";
 import { PlusIcon, UserIcon, UsersIcon, BuildingIcon, LogOutIcon } from "@/components/icons";
+import { LogoMark } from "@/components/logo-mark";
 
 interface TopNavProps {
   onHire: () => void;
@@ -56,13 +57,8 @@ export function TopNav({ onHire, orgName }: TopNavProps) {
       style={{ borderBottom: "1px solid var(--line)", background: "var(--bg)" }}
     >
       <div className="flex items-center gap-2.5 font-semibold text-[15.5px] tracking-tight" style={{ color: "var(--ink)" }}>
-        <div
-          className="w-[26px] h-[26px] rounded-lg grid place-items-center font-mono text-[12px] font-semibold flex-shrink-0"
-          style={{ background: "var(--ink)", color: "var(--bg)" }}
-        >
-          AF
-        </div>
-        Agent Farm
+        <LogoMark size={26} />
+        Agent Barn
       </div>
 
       {orgName && (

--- a/ui/src/features/account/components/slack-token-section.tsx
+++ b/ui/src/features/account/components/slack-token-section.tsx
@@ -92,7 +92,7 @@ export function SlackTokenSection() {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline"
-                  style={{ color: "var(--accent)" }}
+                  style={{ color: "var(--ink-2)" }}
                 >
                   api.slack.com/apps
                 </a>

--- a/ui/src/features/agents/components/agent-card.tsx
+++ b/ui/src/features/agents/components/agent-card.tsx
@@ -31,6 +31,11 @@ export function AgentCard({ agent, onOpen }: AgentCardProps) {
               {formatModelName(agent.model)}
             </div>
           )}
+          {agent.slackConfig?.botDisplayName && (
+            <div className="text-[0.813rem] mt-0.5 truncate" style={{ color: "var(--ink-4)" }}>
+              @{agent.slackConfig.botDisplayName}
+            </div>
+          )}
           <AgentMetaBadges agent={agent} className="mt-2" />
         </div>
       </div>

--- a/ui/src/features/agents/components/agent-detail-page.tsx
+++ b/ui/src/features/agents/components/agent-detail-page.tsx
@@ -115,6 +115,11 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
                     {formatModelName(agent.model)}
                   </div>
                 )}
+                {agent.slackConfig?.botDisplayName && (
+                  <div className="text-[0.875rem] mt-0.5" style={{ color: "var(--ink-4)" }}>
+                    @{agent.slackConfig.botDisplayName}
+                  </div>
+                )}
                 <AgentMetaBadges agent={agent} variant="full" className="mt-2" />
                 <div className="mt-2">
                   <StatusLine status={agent.status} health={health} />

--- a/ui/src/features/agents/components/config-drawer.tsx
+++ b/ui/src/features/agents/components/config-drawer.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import type { Agent } from "../schemas";
+import type { Agent, IntegrationValidationResult } from "../schemas";
 import { useAgentTemplate } from "../hooks/use-agent-template";
 import { useUpdateAgent } from "../hooks/use-update-agent";
 import { useDeleteAgent } from "../hooks/use-delete-agent";
+import { useValidateIntegration } from "../hooks/use-validate-integration";
 import { XIcon, LockIcon } from "@/components/icons";
 import { TokenInput } from "./hire-dialog-primitives";
 import { IntegrationsStep, TemplateSourceBadge, VersionSelect } from "./hire-dialog-steps";
@@ -92,6 +93,40 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
   const tab: TabKey = enabledKeys.includes(activeTab) ? activeTab : "personality";
 
   const configuredSecrets = agent.secrets ?? [];
+  const validateIntegration = useValidateIntegration();
+  const [validationState, setValidationState] = useState<
+    Record<string, IntegrationValidationResult | "loading">
+  >({});
+
+  function triggerValidation(providers?: string[]) {
+    const targets = providers ?? configuredSecrets.map((s) => s.provider);
+    for (const provider of targets) {
+      setValidationState((vs) => ({ ...vs, [provider]: "loading" }));
+      validateIntegration
+        .mutateAsync({ agentId: agent.id, provider })
+        .then(({ provider: p, result }) =>
+          setValidationState((vs) => ({ ...vs, [p]: result })),
+        )
+        .catch(() =>
+          setValidationState((vs) => {
+            const next = { ...vs };
+            delete next[provider];
+            return next;
+          }),
+        );
+    }
+  }
+
+  // Validate all secrets when the secrets tab is already active on mount.
+  useEffect(() => {
+    if (tab === "secrets" && configuredSecrets.length > 0) triggerValidation();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleTabChange(newTab: TabKey) {
+    onTabChange(newTab);
+    if (newTab === "secrets" && configuredSecrets.length > 0) triggerValidation();
+  }
 
   const isRunning = agent.status === "RUNNING";
 
@@ -170,6 +205,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
       // If a provider is both re-added (draft) and removed, treat it as a
       // replace — the upsert wins (the backend rejects a provider in both lists).
       const draftProviders = new Set(secretDrafts.map((d) => d.provider));
+      const updatedProviders = [...draftProviders];
       await updateAgent.mutateAsync({
         agentId: agent.id,
         secrets: secretDrafts.map((d) => ({
@@ -184,6 +220,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
       setRemovedProviders([]);
       setSavedSecrets(true);
       setTimeout(() => setSavedSecrets(false), 2000);
+      if (updatedProviders.length > 0) triggerValidation(updatedProviders);
     } catch {
       setRemovedProviders([]);
       setErrorSection("secrets");
@@ -239,7 +276,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
               className="af-drawer-tab"
               data-active={tab === k}
               disabled={!enabled}
-              onClick={() => enabled && onTabChange(k as TabKey)}
+              onClick={() => enabled && handleTabChange(k as TabKey)}
               style={!enabled ? { opacity: 0.35, cursor: "default" } : undefined}
             >
               {l}
@@ -415,6 +452,11 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
               <Hint>
                 Tokens are write-only — leave a field blank to keep the existing value.
               </Hint>
+              {agent.slackConfig?.botDisplayName && (
+                <div className="text-[0.844rem]" style={{ color: "var(--ink-3)" }}>
+                  Slack bot name: <span className="font-mono" style={{ color: "var(--ink-2)" }}>@{agent.slackConfig.botDisplayName}</span>
+                </div>
+              )}
               <div className="flex flex-col gap-3.5">
                 <div className="flex flex-col gap-1.5">
                   <label className="font-medium text-[0.844rem]" style={{ color: "var(--ink)" }}>App-level token</label>
@@ -555,24 +597,27 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
                     ) : (
                       <div
                         key={s.provider}
-                        className="flex items-center justify-between p-3 rounded-2xl"
+                        className="flex items-center justify-between p-3 rounded-2xl gap-3"
                         style={{ border: "1px solid var(--line)", background: "var(--bg-soft)" }}
                       >
-                        <div className="flex flex-col">
+                        <div className="flex flex-col gap-0.5 min-w-0">
                           <span className="font-semibold text-[0.844rem]" style={{ color: "var(--ink)" }}>
                             {label}
                           </span>
-                          <span className="text-xs" style={{ color: "var(--ink-4)" }}>
-                            {s.secretName} · configured
-                          </span>
+                          <ValidationBadge
+                            secretName={s.secretName}
+                            result={validationState[s.provider]}
+                          />
                         </div>
-                        <button
-                          className="af-btn af-btn-ghost af-btn-sm"
-                          disabled={isRunning}
-                          onClick={() => setRemovedProviders((r) => [...r, s.provider])}
-                        >
-                          Remove
-                        </button>
+                        <div className="flex gap-1.5 shrink-0">
+                          <button
+                            className="af-btn af-btn-ghost af-btn-sm"
+                            disabled={isRunning}
+                            onClick={() => setRemovedProviders((r) => [...r, s.provider])}
+                          >
+                            Remove
+                          </button>
+                        </div>
                       </div>
                     );
                   })}
@@ -667,8 +712,6 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
             <div>
               <Hint>Permanent actions. Pause first if you&apos;re not sure.</Hint>
               <div className="flex gap-2 flex-wrap mt-2">
-                <button className="af-btn">Restart agent</button>
-                <button className="af-btn">Reset workspace</button>
                 <button
                   className="af-btn"
                   style={{ borderColor: "var(--err)", color: "var(--err)" }}
@@ -735,6 +778,59 @@ function Hint({ children }: { children: React.ReactNode }) {
     >
       {children}
     </div>
+  );
+}
+
+function ValidationBadge({
+  secretName,
+  result,
+}: {
+  secretName: string;
+  result: IntegrationValidationResult | "loading" | undefined;
+}) {
+  if (result === undefined) {
+    return (
+      <span className="text-xs" style={{ color: "var(--ink-4)" }}>
+        {secretName} · not yet validated
+      </span>
+    );
+  }
+
+  if (result === "loading") {
+    return (
+      <span className="text-xs" style={{ color: "var(--ink-4)" }}>
+        Checking…
+      </span>
+    );
+  }
+
+  if (result.validationStatus === "valid") {
+    return (
+      <span className="text-xs" style={{ color: "var(--ok)" }}>
+        ✓ {result.validationIdentity ?? "Connected"}
+      </span>
+    );
+  }
+
+  if (result.validationStatus === "warning") {
+    return (
+      <div className="flex flex-col gap-0.5">
+        <span className="text-xs" style={{ color: "var(--warn)" }}>
+          ⚠ {result.validationIdentity ?? "Connected"} — missing scopes
+        </span>
+        {result.missingScopes.length > 0 && (
+          <span className="text-xs" style={{ color: "var(--ink-4)" }}>
+            {result.missingScopes.join(", ")}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <span className="text-xs" style={{ color: "var(--err)" }}>
+      ✕ {result.validationError ?? "Invalid credentials"}
+    </span>
   );
 }
 

--- a/ui/src/features/agents/components/config-drawer.tsx
+++ b/ui/src/features/agents/components/config-drawer.tsx
@@ -119,7 +119,10 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
 
   // Validate all secrets when the secrets tab is already active on mount.
   useEffect(() => {
-    if (tab === "secrets" && configuredSecrets.length > 0) triggerValidation();
+    if (tab === "secrets" && configuredSecrets.length > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      triggerValidation();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/ui/src/features/agents/components/hire-dialog-steps.tsx
+++ b/ui/src/features/agents/components/hire-dialog-steps.tsx
@@ -46,7 +46,6 @@ export type WizardStep =
 export const TEMPLATE_FILE_KEYS = [
   "soulMd",
   "identityMd",
-  "userMd",
   "toolsMd",
   "agentsMd",
   "bootMd",
@@ -786,15 +785,15 @@ export function generateTeamsManifest(
       id: appId || "{{YOUR_APP_ID}}",
       packageName: "com.agentfarm.bot",
       developer: {
-        name: "Agent Farm",
+        name: "Agent Barn",
         websiteUrl: "https://agent-farm.k8s.aai-labs.com",
         privacyUrl: "https://agent-farm.k8s.aai-labs.com",
         termsOfUseUrl: "https://agent-farm.k8s.aai-labs.com",
       },
-      name: { short: botName, full: `${botName} - Agent Farm` },
+      name: { short: botName, full: `${botName} - Agent Barn` },
       description: {
         short: botDescription,
-        full: `${botDescription}\n\nPowered by Agent Farm.`,
+        full: `${botDescription}\n\nPowered by Agent Barn.`,
       },
       icons: { color: "color.png", outline: "outline.png" },
       accentColor,
@@ -1370,6 +1369,11 @@ export function SkillsStep({
                     Required
                   </span>
                 </div>
+                {providerSpec.scopeNote && (
+                  <p className="text-[0.75rem] leading-[1.4]" style={{ color: "var(--ink-3)" }}>
+                    {providerSpec.scopeNote}
+                  </p>
+                )}
                 {providerSpec.fields.map((field) => {
                   const value = draft.content[field.key] ?? "";
                   const label = field.required ? field.label : `${field.label} (optional)`;
@@ -1492,6 +1496,11 @@ export function IntegrationsStep({
                 <XIcon size={15} />
               </button>
             </div>
+            {provider.scopeNote && (
+              <p className="text-[0.75rem] leading-[1.4]" style={{ color: "var(--ink-3)" }}>
+                {provider.scopeNote}
+              </p>
+            )}
 
             {provider.fields.map((field) => {
               const value = draft.content[field.key] ?? "";

--- a/ui/src/features/agents/components/template-drawer.tsx
+++ b/ui/src/features/agents/components/template-drawer.tsx
@@ -19,7 +19,6 @@ type TemplateFiles = Record<TemplateFileKey, string>;
 const EMPTY_FILES: TemplateFiles = {
   soulMd: "",
   identityMd: "",
-  userMd: "",
   toolsMd: "",
   agentsMd: "",
   bootMd: "",
@@ -31,7 +30,6 @@ function filesFrom(template: AgentTemplateRead): TemplateFiles {
   return {
     soulMd: template.soulMd,
     identityMd: template.identityMd,
-    userMd: template.userMd,
     toolsMd: template.toolsMd,
     agentsMd: template.agentsMd,
     bootMd: template.bootMd,

--- a/ui/src/features/agents/components/templates-panel.tsx
+++ b/ui/src/features/agents/components/templates-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { ChevronDownIcon } from "lucide-react";
-import { PlusIcon, SearchIcon } from "@/components/icons";
+import { PlusIcon } from "@/components/icons";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/ui/src/features/agents/hooks/use-validate-integration.ts
+++ b/ui/src/features/agents/hooks/use-validate-integration.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+
+import { api } from "@/shared/api";
+
+import { IntegrationValidationResult, IntegrationValidationResultSchema } from "../schemas";
+
+export function useValidateIntegration() {
+  return useMutation({
+    mutationFn: async ({
+      agentId,
+      provider,
+    }: {
+      agentId: string;
+      provider: string;
+    }): Promise<{ provider: string; result: IntegrationValidationResult }> => {
+      const response = await api.post<IntegrationValidationResult>(
+        `/api/v1/agents/${agentId}/integrations/${provider}/validate`,
+        {},
+        { schema: IntegrationValidationResultSchema },
+      );
+      return { provider, result: response.data };
+    },
+  });
+}

--- a/ui/src/features/agents/integrations.ts
+++ b/ui/src/features/agents/integrations.ts
@@ -86,7 +86,8 @@ export function expandGithubContent(content: Record<string, string>): Record<str
   const parsed = parseGithubRepoUrl(content.repoUrl ?? "");
   if (!parsed) return content;
   const { owner, repo } = parsed;
-  const { repoUrl: _, ...rest } = content;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { repoUrl: _repoUrl, ...rest } = content;
   return { ...rest, owner, repo, org: owner };
 }
 

--- a/ui/src/features/agents/integrations.ts
+++ b/ui/src/features/agents/integrations.ts
@@ -21,6 +21,7 @@ export interface IntegrationField {
 export interface IntegrationProvider {
   id: string;
   label: string;
+  scopeNote?: string;
   fields: IntegrationField[];
 }
 
@@ -33,6 +34,7 @@ export const INTEGRATION_PROVIDERS: IntegrationProvider[] = [
   {
     id: "github",
     label: "GitHub",
+    scopeNote: "Classic PAT: repo, read:user, read:org — Fine-grained PAT: Contents (read), Pull requests (read + write), Metadata (read, mandatory)",
     fields: [
       { key: "token", label: "Personal access token", type: "secret", required: true, placeholder: "github_pat_… or ghp_…" },
       { key: "repoUrl", label: "Repository URL", type: "repo-url", required: true, placeholder: "https://github.com/owner/repo.git" },
@@ -41,6 +43,7 @@ export const INTEGRATION_PROVIDERS: IntegrationProvider[] = [
   {
     id: "jira",
     label: "Jira",
+    scopeNote: "API token inherits your Atlassian account's project permissions — account needs Browse Projects and Add Comments on the target project",
     fields: [
       { key: "siteUrl", label: "Site URL", type: "text", required: true, placeholder: "https://your-domain.atlassian.net" },
       { key: "email", label: "Email", type: "text", required: true, placeholder: "you@example.com" },
@@ -50,6 +53,7 @@ export const INTEGRATION_PROVIDERS: IntegrationProvider[] = [
   {
     id: "confluence",
     label: "Confluence",
+    scopeNote: "API token inherits your Atlassian account's space permissions — account needs Space View and Add Page Comments on the target space",
     fields: [
       { key: "siteUrl", label: "Site URL", type: "text", required: true, placeholder: "https://your-domain.atlassian.net" },
       { key: "email", label: "Email", type: "text", required: true, placeholder: "you@example.com" },
@@ -59,6 +63,7 @@ export const INTEGRATION_PROVIDERS: IntegrationProvider[] = [
   {
     id: "bitbucket",
     label: "Bitbucket",
+    scopeNote: "App password scopes: Account (read), Repositories (read), Pull requests (read + write)",
     fields: [
       { key: "workspace", label: "Workspace", type: "text", required: true, placeholder: "workspace id" },
       { key: "repo", label: "Repository", type: "text", required: true, placeholder: "repository" },

--- a/ui/src/features/agents/schemas.ts
+++ b/ui/src/features/agents/schemas.ts
@@ -5,6 +5,7 @@ export const AgentSlackConfigSchema = z.object({
   dmUserIds: z.array(z.string()),
   groupPolicy: z.enum(["open", "allowlist"]),
   dmPolicy: z.enum(["off", "open", "allowlist"]),
+  botDisplayName: z.string().nullable().optional(),
 });
 
 export const AgentTeamsConfigSchema = z.object({
@@ -15,6 +16,16 @@ export const AgentSecretReadSchema = z.object({
   provider: z.string(),
   secretName: z.string(),
 });
+
+export const IntegrationValidationResultSchema = z.object({
+  validationStatus: z.enum(["valid", "warning", "invalid"]),
+  validationIdentity: z.string().nullable().optional(),
+  validationError: z.string().nullable().optional(),
+  missingScopes: z.array(z.string()).default([]),
+});
+
+export type AgentSecretRead = z.infer<typeof AgentSecretReadSchema>;
+export type IntegrationValidationResult = z.infer<typeof IntegrationValidationResultSchema>;
 
 export const AgentAssignedSkillSchema = z.object({
   id: z.string().uuid(),

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -482,7 +482,7 @@ test.describe("Agent Detail Page — Keys tab", () => {
     await agentDetailPage.configureButton().click();
     await agentDetailPage.keysTab().click();
 
-    await expect(page.getByText("· configured")).toBeVisible();
+    await expect(page.getByText("· not yet validated")).toBeVisible();
     await expect(agentDetailPage.removeCredentialButton()).toBeVisible();
   });
 
@@ -512,7 +512,7 @@ test.describe("Agent Detail Page — Keys tab", () => {
     await agentDetailPage.removeCredentialButton().click();
     await agentDetailPage.undoCredentialButton().click();
 
-    await expect(page.getByText("· configured")).toBeVisible();
+    await expect(page.getByText("· not yet validated")).toBeVisible();
     await expect(agentDetailPage.removeCredentialButton()).toBeVisible();
     await expect(agentDetailPage.saveIntegrationsButton()).toBeDisabled();
   });
@@ -533,7 +533,7 @@ test.describe("Agent Detail Page — Keys tab", () => {
     await agentDetailPage.saveIntegrationsButton().click();
 
     await expect(page.getByText("Secret is used by a skill")).toBeVisible();
-    await expect(page.getByText("· configured")).toBeVisible();
+    await expect(page.getByText("· not yet validated")).toBeVisible();
   });
 
   test("error from token save does not appear in integrations section", async ({ page }) => {


### PR DESCRIPTION
Adds per-provider credential validation for all four integrations and shows the Slack bot's display name across the agent list, detail page, and config drawer.

What's included
- Integration validators (api/infrastructure/integration_validators/) — GitHub (classic + fine-grained PAT), Jira, Confluence, Bitbucket (app passwords, personal API tokens, workspace/repo HTTP access tokens); 42 unit tests
- Config drawer — validation runs on save; valid/missing-scope badges shown per provider; re-validate button removed (save is the trigger)
- Slack bot name — fetched live from Slack API after hire/token-update, cached 60 s in memory, displayed as @name in agent card, detail page, and config drawer; bot_display_name DB column removed (migration downgraded and deleted)
- Test fixes — test_update_slack_app_name_success decoded form body correctly; _resp helper accepts list | dict; template-drawer.tsx userMd TS error resolved
- Helm charts — both agentfarm-api and agentfarm-ui bumped 0.3.0 → 0.4.0