### PR TITLE
Af 148 point app agentbarn dev to the app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,10 +77,13 @@ jobs:
           docker push '${{ secrets.REGISTRY_URL }}/agentfarm-api:${{ env.API_IMAGE_TAG }}'
           docker push '${{ secrets.REGISTRY_URL }}/agentfarm-api:latest'
 
+      - name: Extract primary API host
+        run: echo "PRIMARY_API_HOST=$(echo '${{ vars.API_HOST }}' | cut -d',' -f1 | tr -d ' ')" >> $GITHUB_ENV
+
       - name: Build and push UI image
         run: |
           docker build \
-            --build-arg NEXT_PUBLIC_BACKEND_URL=https://${{ secrets.API_HOST }} \
+            --build-arg NEXT_PUBLIC_BACKEND_URL=https://${{ env.PRIMARY_API_HOST }} \
             -t '${{ secrets.REGISTRY_URL }}/agentfarm-ui:${{ env.UI_IMAGE_TAG }}' \
             -t '${{ secrets.REGISTRY_URL }}/agentfarm-ui:latest' \
             -f ui/Dockerfile \
@@ -170,8 +173,8 @@ jobs:
           AGENT_TOKEN_ENCRYPTION_KEY: ${{ secrets.AGENT_TOKEN_ENCRYPTION_KEY }}
           ENVIRONMENT: production
           WEB_APP_URL: ${{ secrets.WEB_APP_URL }}
-          API_HOST: ${{ secrets.API_HOST }}
-          UI_HOST: ${{ secrets.UI_HOST }}
+          API_HOST: ${{ vars.API_HOST }}
+          UI_HOST: ${{ vars.UI_HOST }}
           KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
           POD_KUBECONFIG_B64: ${{ secrets.POD_KUBECONFIG_B64 }}
           REGISTRY_SERVER: ${{ secrets.REGISTRY_URL }}

--- a/api/domains/agents/builders/hermes.py
+++ b/api/domains/agents/builders/hermes.py
@@ -217,7 +217,6 @@ def build_hermes_deployment(
                         client.V1Container(
                             name="agent",
                             image=image,
-                            image_pull_policy="Never",
                             command=["sh", "/app/config/start.sh"],
                             readiness_probe=client.V1Probe(
                                 http_get=client.V1HTTPGetAction(

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.19.0"

--- a/helm/agentfarm-api/templates/ingress.yaml
+++ b/helm/agentfarm-api/templates/ingress.yaml
@@ -13,16 +13,20 @@ spec:
   ingressClassName: traefik
   tls:
     - hosts:
-        - {{ .Values.ingress.host }}
+        {{- range splitList "," .Values.ingress.hosts }}
+        - {{ . | trim }}
+        {{- end }}
       secretName: {{ .Values.ingress.tlsSecretName }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range splitList "," .Values.ingress.hosts }}
+    - host: {{ . | trim }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ .Release.Name }}
+                name: {{ $.Release.Name }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+    {{- end }}

--- a/helm/agentfarm-api/values.yaml
+++ b/helm/agentfarm-api/values.yaml
@@ -66,7 +66,7 @@ service:
 apiExternalUrl: "https://api.agent-farm.k8s.aai-labs.com"
 
 ingress:
-  host: api.agent-farm.k8s.aai-labs.com
+  hosts: "api.agent-farm.k8s.aai-labs.com"
   clusterIssuer: letsencrypt-http01
   tlsSecretName: agentfarm-api-tls
 

--- a/helm/agentfarm-ui/Chart.yaml
+++ b/helm/agentfarm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: agentfarm-ui
 description: Next.js frontend for agent-farm
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.18.0"

--- a/helm/agentfarm-ui/templates/ingress.yaml
+++ b/helm/agentfarm-ui/templates/ingress.yaml
@@ -13,16 +13,20 @@ spec:
   ingressClassName: traefik
   tls:
     - hosts:
-        - {{ .Values.ingress.host }}
+        {{- range splitList "," .Values.ingress.hosts }}
+        - {{ . | trim }}
+        {{- end }}
       secretName: {{ .Values.ingress.tlsSecretName }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range splitList "," .Values.ingress.hosts }}
+    - host: {{ . | trim }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ .Release.Name }}
+                name: {{ $.Release.Name }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
+    {{- end }}

--- a/helm/agentfarm-ui/values.yaml
+++ b/helm/agentfarm-ui/values.yaml
@@ -13,7 +13,7 @@ service:
   port: 3000
 
 ingress:
-  host: agent-farm.k8s.aai-labs.com
+  hosts: "agent-farm.k8s.aai-labs.com"
   clusterIssuer: letsencrypt-http01
   tlsSecretName: agentfarm-ui-tls
 

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -87,7 +87,7 @@ releases:
       - name: webAppUrl
         value: {{ env "WEB_APP_URL" | required "WEB_APP_URL is required" | quote }}
       - name: apiExternalUrl
-        value: {{ printf "https://%s" (env "API_HOST" | required "API_HOST is required") | quote }}
+        value: {{ printf "https://%s" (env "API_HOST" | required "API_HOST is required" | splitList "," | first | trim) | quote }}
       - name: kubeconfigB64
         value: {{ env "POD_KUBECONFIG_B64" | required "POD_KUBECONFIG_B64 is required" | quote }}
       - name: storageClass
@@ -102,7 +102,7 @@ releases:
         value: {{ env "REGISTRY_USERNAME" | required "REGISTRY_USERNAME is required" | quote }}
       - name: registry.password
         value: {{ env "REGISTRY_PASSWORD" | required "REGISTRY_PASSWORD is required" | quote }}
-      - name: ingress.host
+      - name: ingress.hosts
         value: {{ env "API_HOST" | required "API_HOST is required" | quote }}
     needs:
       - agent-farm/postgres-app
@@ -118,7 +118,7 @@ releases:
         value: {{ env "REGISTRY_PREFIX" | default "registry.k8s.aai-labs.com" | quote }}
       - name: image.repository
         value: {{ env "UI_IMAGE_REPOSITORY" | default "agentfarm-ui" | quote }}
-      - name: ingress.host
+      - name: ingress.hosts
         value: {{ env "UI_HOST" | required "UI_HOST is required" | quote }}
     needs:
       - agent-farm/agentfarm-api


### PR DESCRIPTION
Support comma-separated hostnames for UI_HOST and API_HOST                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - ingress.host renamed to ingress.hosts (comma-separated string) in both agentfarm-ui and agentfarm-api Helm charts                                                                                                                                                                                                                                                                                                             
  - Ingress templates updated to iterate over the host list with splitList "," — generates one rules entry per hostname and a single SAN TLS block covering all of them (cert-manager issues one cert)                                                                                                                                                                                                                            
  - helmfile.yaml.gotmpl updated to pass ingress.hosts and to extract the first hostname in API_HOST for apiExternalUrl (webhook callbacks require a single URL)                                                                                                                                                                                                                                                                  
  - API_HOST and UI_HOST moved from GitHub secrets to GitHub variables (vars.*)                                                                                                                                                                                                                                                                                                                                                   
  - Deploy workflow extracts the primary API host (cut -d',' -f1) before baking NEXT_PUBLIC_BACKEND_URL into the UI image                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  To activate app.agentbarn.dev:                                                                                                                                                                                                                                                                                                                                                                                                  
  1. Set GitHub variable UI_HOST to agent-farm.k8s.aai-labs.com,app.agentbarn.dev                                                                                                                                                                                                                                                                                                                                                 
  2. Point DNS for app.agentbarn.dev to the cluster ingress IP                                                                                                                                                                                                                                                                                                                                                                    
  3. Trigger the deploy workflow