### PR TITLE
Af 141 connect templates and skills

### DIFF
--- a/api/api_app.py
+++ b/api/api_app.py
@@ -56,6 +56,8 @@ async def lifespan(_: FastAPI):
         default_org = org_service.ensure_default_organization()
         set_default_org_id(default_org.id)
 
+        seed_aai_cli_skills(injector.get(SkillRepository))
+
         template_service = injector.get(TemplateService)
         template_service.seed_predefined_templates(default_org.id)
 
@@ -70,8 +72,6 @@ async def lifespan(_: FastAPI):
                     role=OrganizationRole.OWNER,
                 )
             )
-
-        seed_aai_cli_skills(injector.get(SkillRepository))
     except Exception:
         logger.error("Error during startup bootstrap: %s", traceback.format_exc())
         raise HTTPException(

--- a/api/domains/agents/models.py
+++ b/api/domains/agents/models.py
@@ -279,6 +279,22 @@ class AgentSkill(BaseModel, table=True):
     )
 
 
+class AgentTemplateSkill(BaseModel, table=True):
+    __tablename__: str = "agent_template_skill"
+
+    __table_args__ = (
+        sa.UniqueConstraint("template_id", "skill_id", name="uq_agent_template_skill"),
+        sa.Index("ix_agent_template_skill_template", "template_id"),
+    )
+
+    template_id: UUID = SqlField(
+        foreign_key="agent_template.id", nullable=False, ondelete="CASCADE"
+    )
+    skill_id: UUID = SqlField(
+        foreign_key="skill.id", nullable=False, ondelete="RESTRICT"
+    )
+
+
 class AgentSecretCreate(PydanticBaseModel):  # no secret_name — backend stamps it
     provider: SecretProvider
     content: dict
@@ -430,6 +446,7 @@ class AgentAssignedSkillRead(PydanticBaseModel):
     tools_pointer: str | None
     created_at: datetime
     updated_at: datetime
+    required: bool = False
 
 
 class AgentRead(PydanticBaseModel):

--- a/api/domains/agents/service.py
+++ b/api/domains/agents/service.py
@@ -463,6 +463,16 @@ class AgentService:
                     detail="LiteLLM key generation failed; cannot create agent.",
                 ) from exc
 
+        # Validate that all template-required skills are present in the request.
+        required_ids = self.template_repository.get_required_skill_ids(template.id)
+        if required_ids:
+            missing = required_ids - set(data.skill_ids)
+            if missing:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Required template skills must be included in skill_ids",
+                )
+
         self.repository.save(agent)
 
         slack_config = None
@@ -519,16 +529,6 @@ class AgentService:
                 )
             )
             secrets.append(saved)
-
-        # Validate that all template-required skills are present in the request.
-        required_ids = self.template_repository.get_required_skill_ids(template.id)
-        if required_ids:
-            missing = required_ids - set(data.skill_ids)
-            if missing:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Required template skills must be included in skill_ids",
-                )
 
         # Resolve and validate skills before any DB writes.
         skills_to_assign = self._resolve_skills(data.skill_ids, data.secrets, org_id)
@@ -671,6 +671,48 @@ class AgentService:
             self._ensure_model_allowed(updated["model"])
             agent.model = updated["model"]
 
+        # Validate skill changes against the effective template's required skills
+        if effective_template is None:
+            effective_template = (
+                self.template_repository.get_template_by_slug_and_version(
+                    org_id, agent.template_slug, agent.template_version
+                )
+            )
+        required_ids = (
+            self.template_repository.get_required_skill_ids(effective_template.id)
+            if effective_template
+            else set()
+        )
+        if required_ids:
+            # Block removal of required skills.
+            if data.removed_skill_ids:
+                blocked = required_ids & set(data.removed_skill_ids)
+                if blocked:
+                    blocked_skills = self.skill_repository.get_many_by_ids(
+                        list(blocked)
+                    )
+                    names = ", ".join(s.name for s in blocked_skills)
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=f"Cannot remove skills required by the template: {names}",
+                    )
+            # When re-pinning, validate that required skills will be present.
+            if "template_slug" in updated:
+                existing_skill_ids = {
+                    s.id
+                    for _, s in self.skill_repository.get_agent_skills_with_details(
+                        agent.id
+                    )
+                }
+                effective_skill_ids = (existing_skill_ids | set(data.skill_ids)) - set(
+                    data.removed_skill_ids
+                )
+                if required_ids - effective_skill_ids:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Required template skills must be included in skill_ids",
+                    )
+
         # Slack config updates
         if agent.platform == AgentPlatform.SLACK and (
             _SLACK_CONFIG_FIELDS & updated.keys()
@@ -729,48 +771,6 @@ class AgentService:
                 if "teams_tenant_id" in updated:
                     teams_config.tenant_id = updated["teams_tenant_id"]
                 self.repository.save_teams_config(teams_config)
-
-        # Validate skill changes against the effective template's required skills.
-        if effective_template is None:
-            effective_template = (
-                self.template_repository.get_template_by_slug_and_version(
-                    org_id, agent.template_slug, agent.template_version
-                )
-            )
-        required_ids = (
-            self.template_repository.get_required_skill_ids(effective_template.id)
-            if effective_template
-            else set()
-        )
-        if required_ids:
-            # Block removal of required skills.
-            if data.removed_skill_ids:
-                blocked = required_ids & set(data.removed_skill_ids)
-                if blocked:
-                    blocked_skills = self.skill_repository.get_many_by_ids(
-                        list(blocked)
-                    )
-                    names = ", ".join(s.name for s in blocked_skills)
-                    raise HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail=f"Cannot remove skills required by the template: {names}",
-                    )
-            # When re-pinning, validate that required skills will be present.
-            if "template_slug" in updated:
-                existing_skill_ids = {
-                    s.id
-                    for _, s in self.skill_repository.get_agent_skills_with_details(
-                        agent.id
-                    )
-                }
-                effective_skill_ids = (existing_skill_ids | set(data.skill_ids)) - set(
-                    data.removed_skill_ids
-                )
-                if required_ids - effective_skill_ids:
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail="Required template skills must be included in skill_ids",
-                    )
 
         # Validate skills accessibility and secret coverage
         if data.skill_ids or data.removed_secret_providers:

--- a/api/domains/agents/service.py
+++ b/api/domains/agents/service.py
@@ -276,6 +276,7 @@ class AgentService:
         teams_config: AgentTeamsConfig | None = None,
         secrets: list[AgentSecret] | None = None,
         skills: list[Skill] | None = None,
+        required_skill_ids: set[UUID] | None = None,
     ) -> AgentRead:
         slack_config_read = (
             AgentSlackConfigRead.model_validate(slack_config) if slack_config else None
@@ -286,8 +287,12 @@ class AgentService:
         secrets_read = [
             AgentSecretRead.model_validate(secret) for secret in (secrets or [])
         ]
+        req_ids = required_skill_ids or set()
         skills_read = [
-            AgentAssignedSkillRead.model_validate(skill) for skill in (skills or [])
+            AgentAssignedSkillRead.model_validate(skill).model_copy(
+                update={"required": skill.id in req_ids}
+            )
+            for skill in (skills or [])
         ]
         webhook_url = (
             f"{self.config.api_external_url}/api/v1/webhooks/teams/{agent.id}/messages"
@@ -324,8 +329,15 @@ class AgentService:
         skills = [
             s for _, s in self.skill_repository.get_agent_skills_with_details(agent.id)
         ]
+        template = self.template_repository.get_template_by_slug_and_version(
+            agent.organization_id, agent.template_slug, agent.template_version
+        )
+        required_ids = (
+            self.template_repository.get_required_skill_ids(template.id)
+            if template else set()
+        )
         return self._build_agent_read(
-            agent, slack_config, teams_config, secrets, skills
+            agent, slack_config, teams_config, secrets, skills, required_ids
         )
 
     def create_agent(self, data: AgentCreate, context: CurrentUserContext) -> AgentRead:
@@ -441,6 +453,16 @@ class AgentService:
                 )
             )
 
+        # Validate that all template-required skills are present in the request.
+        required_ids = self.template_repository.get_required_skill_ids(template.id)
+        if required_ids:
+            missing = required_ids - set(data.skill_ids)
+            if missing:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Required template skills must be included in skill_ids",
+                )
+
         # Resolve and validate skills before any DB writes.
         skills_to_assign = self._resolve_skills(data.skill_ids, data.secrets, org_id)
 
@@ -452,7 +474,7 @@ class AgentService:
         if data.platform == AgentPlatform.TEAMS:
             return self.start_agent(agent.id, context)
         return self._build_agent_read(
-            agent, slack_config, teams_config, secrets, skills_to_assign
+            agent, slack_config, teams_config, secrets, skills_to_assign, required_ids
         )
 
     def get_agent(self, agent_id: UUID, context: CurrentUserContext) -> AgentRead:
@@ -492,6 +514,19 @@ class AgentService:
         secrets_by_agent = self.repository.get_secrets_for_agents(agent_ids)
         skills_by_agent = self.skill_repository.get_skills_for_agents(agent_ids)
 
+        slug_versions = list({(a.template_slug, a.template_version) for a in agents})
+        template_id_map = self.template_repository.get_template_ids_for_slug_versions(
+            org_id, slug_versions
+        )
+        template_ids = list(template_id_map.values())
+        req_ids_by_template = self.template_repository.get_required_skill_ids_for_templates(
+            template_ids
+        )
+
+        def _required_ids(agent: Agent) -> set[UUID]:
+            tid = template_id_map.get((agent.template_slug, agent.template_version))
+            return req_ids_by_template.get(tid, set()) if tid else set()
+
         items = [
             self._build_agent_read(
                 agent,
@@ -499,6 +534,7 @@ class AgentService:
                 teams_configs.get(agent.id),
                 secrets_by_agent.get(agent.id, []),
                 skills_by_agent.get(agent.id, []),
+                _required_ids(agent),
             )
             for agent in agents
         ]
@@ -541,11 +577,12 @@ class AgentService:
 
         # Re-pin the agent to a different template (slug, version). The model
         # validator guarantees both keys appear together.
+        effective_template = None
         if "template_slug" in updated:
-            target = self.template_repository.get_template_by_slug_and_version(
+            effective_template = self.template_repository.get_template_by_slug_and_version(
                 org_id, updated["template_slug"], updated["template_version"]
             )
-            if target is None:
+            if effective_template is None:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=(
@@ -553,8 +590,8 @@ class AgentService:
                         f"v{updated['template_version']} not found"
                     ),
                 )
-            agent.template_slug = target.template_slug
-            agent.template_version = target.version
+            agent.template_slug = effective_template.template_slug
+            agent.template_version = effective_template.version
 
         if "name" in updated:
             agent.name = updated["name"]
@@ -620,6 +657,41 @@ class AgentService:
                 if "teams_tenant_id" in updated:
                     teams_config.tenant_id = updated["teams_tenant_id"]
                 self.repository.save_teams_config(teams_config)
+
+        # Validate skill changes against the effective template's required skills.
+        if effective_template is None:
+            effective_template = self.template_repository.get_template_by_slug_and_version(
+                org_id, agent.template_slug, agent.template_version
+            )
+        required_ids = (
+            self.template_repository.get_required_skill_ids(effective_template.id)
+            if effective_template else set()
+        )
+        if required_ids:
+            # Block removal of required skills.
+            if data.removed_skill_ids:
+                blocked = required_ids & set(data.removed_skill_ids)
+                if blocked:
+                    blocked_skills = self.skill_repository.get_many_by_ids(list(blocked))
+                    names = ", ".join(s.name for s in blocked_skills)
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=f"Cannot remove skills required by the template: {names}",
+                    )
+            # When re-pinning, validate that required skills will be present.
+            if "template_slug" in updated:
+                existing_skill_ids = {
+                    s.id
+                    for _, s in self.skill_repository.get_agent_skills_with_details(agent.id)
+                }
+                effective_skill_ids = (
+                    existing_skill_ids | set(data.skill_ids)
+                ) - set(data.removed_skill_ids)
+                if required_ids - effective_skill_ids:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Required template skills must be included in skill_ids",
+                    )
 
         # Validate skills accessibility and secret coverage
         if data.skill_ids or data.removed_secret_providers:

--- a/api/domains/agents/service.py
+++ b/api/domains/agents/service.py
@@ -334,7 +334,8 @@ class AgentService:
         )
         required_ids = (
             self.template_repository.get_required_skill_ids(template.id)
-            if template else set()
+            if template
+            else set()
         )
         return self._build_agent_read(
             agent, slack_config, teams_config, secrets, skills, required_ids
@@ -519,8 +520,8 @@ class AgentService:
             org_id, slug_versions
         )
         template_ids = list(template_id_map.values())
-        req_ids_by_template = self.template_repository.get_required_skill_ids_for_templates(
-            template_ids
+        req_ids_by_template = (
+            self.template_repository.get_required_skill_ids_for_templates(template_ids)
         )
 
         def _required_ids(agent: Agent) -> set[UUID]:
@@ -579,8 +580,10 @@ class AgentService:
         # validator guarantees both keys appear together.
         effective_template = None
         if "template_slug" in updated:
-            effective_template = self.template_repository.get_template_by_slug_and_version(
-                org_id, updated["template_slug"], updated["template_version"]
+            effective_template = (
+                self.template_repository.get_template_by_slug_and_version(
+                    org_id, updated["template_slug"], updated["template_version"]
+                )
             )
             if effective_template is None:
                 raise HTTPException(
@@ -660,19 +663,24 @@ class AgentService:
 
         # Validate skill changes against the effective template's required skills.
         if effective_template is None:
-            effective_template = self.template_repository.get_template_by_slug_and_version(
-                org_id, agent.template_slug, agent.template_version
+            effective_template = (
+                self.template_repository.get_template_by_slug_and_version(
+                    org_id, agent.template_slug, agent.template_version
+                )
             )
         required_ids = (
             self.template_repository.get_required_skill_ids(effective_template.id)
-            if effective_template else set()
+            if effective_template
+            else set()
         )
         if required_ids:
             # Block removal of required skills.
             if data.removed_skill_ids:
                 blocked = required_ids & set(data.removed_skill_ids)
                 if blocked:
-                    blocked_skills = self.skill_repository.get_many_by_ids(list(blocked))
+                    blocked_skills = self.skill_repository.get_many_by_ids(
+                        list(blocked)
+                    )
                     names = ", ".join(s.name for s in blocked_skills)
                     raise HTTPException(
                         status_code=status.HTTP_409_CONFLICT,
@@ -682,11 +690,13 @@ class AgentService:
             if "template_slug" in updated:
                 existing_skill_ids = {
                     s.id
-                    for _, s in self.skill_repository.get_agent_skills_with_details(agent.id)
+                    for _, s in self.skill_repository.get_agent_skills_with_details(
+                        agent.id
+                    )
                 }
-                effective_skill_ids = (
-                    existing_skill_ids | set(data.skill_ids)
-                ) - set(data.removed_skill_ids)
+                effective_skill_ids = (existing_skill_ids | set(data.skill_ids)) - set(
+                    data.removed_skill_ids
+                )
                 if required_ids - effective_skill_ids:
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/domains/skills/repository.py
+++ b/api/domains/skills/repository.py
@@ -5,7 +5,7 @@ from injector import inject, singleton
 from sqlalchemy import func
 from sqlmodel import Session, col, or_, select
 
-from api.domains.agents.models import AgentSkill
+from api.domains.agents.models import AgentSkill, AgentTemplateSkill
 from api.domains.skills.models import Skill, SkillFilter, SkillSource
 from api.infrastructure.postgres.repository import PostgresRepositoryDelegate
 from api.infrastructure.shared.models import Pagination
@@ -90,6 +90,13 @@ class SkillRepository:
     def is_assigned_to_any_agent(self, skill_id: UUID) -> bool:
         with Session(self.delegate.engine) as session:
             query = select(AgentSkill).where(col(AgentSkill.skill_id) == skill_id)
+            return session.exec(query).first() is not None
+
+    def is_required_by_any_template(self, skill_id: UUID) -> bool:
+        with Session(self.delegate.engine) as session:
+            query = select(AgentTemplateSkill).where(
+                col(AgentTemplateSkill.skill_id) == skill_id
+            )
             return session.exec(query).first() is not None
 
     def get_agent_skills_with_details(

--- a/api/domains/skills/repository.py
+++ b/api/domains/skills/repository.py
@@ -3,9 +3,10 @@ from uuid import UUID
 
 from injector import inject, singleton
 from sqlalchemy import func
-from sqlmodel import Session, col, or_, select
+from sqlmodel import Session, col, delete, or_, select
 
 from api.domains.agents.models import Agent, AgentSkill, AgentTemplateSkill
+from api.domains.templates.models import AgentTemplate
 from api.domains.skills.models import Skill, SkillFilter, SkillSource
 from api.infrastructure.postgres.repository import PostgresRepositoryDelegate
 from api.infrastructure.shared.models import Pagination
@@ -97,12 +98,57 @@ class SkillRepository:
             )
             return session.exec(query).first() is not None
 
-    def is_required_by_any_template(self, skill_id: UUID) -> bool:
+    def get_latest_template_slugs_requiring_skill(
+        self, skill_id: UUID, org_id: UUID
+    ) -> list[str]:
+        """Return template slugs whose *latest* version lists this skill as required."""
         with Session(self.delegate.engine) as session:
-            query = select(AgentTemplateSkill).where(
-                col(AgentTemplateSkill.skill_id) == skill_id
+            latest = (
+                select(AgentTemplate.id)
+                .distinct(col(AgentTemplate.template_slug))
+                .where(col(AgentTemplate.organization_id) == org_id)
+                .order_by(
+                    col(AgentTemplate.template_slug).asc(),
+                    col(AgentTemplate.version).desc(),
+                )
+                .subquery()
             )
-            return session.exec(query).first() is not None
+            query = (
+                select(AgentTemplate.template_slug)
+                .join(
+                    AgentTemplateSkill,
+                    col(AgentTemplate.id) == col(AgentTemplateSkill.template_id),
+                )
+                .where(col(AgentTemplate.id).in_(select(latest.c.id)))
+                .where(col(AgentTemplateSkill.skill_id) == skill_id)
+            )
+            return list(session.exec(query).all())
+
+    def delete_stale_template_skill_refs(self, skill_id: UUID, org_id: UUID) -> None:
+        """Delete agent_template_skill rows for non-latest template versions.
+
+        When deletion is allowed (latest version no longer requires the skill),
+        historical join rows from superseded versions must be removed first to
+        satisfy the RESTRICT FK constraint on skill.id.
+        """
+        with Session(self.delegate.engine) as session:
+            latest = (
+                select(AgentTemplate.id)
+                .distinct(col(AgentTemplate.template_slug))
+                .where(col(AgentTemplate.organization_id) == org_id)
+                .order_by(
+                    col(AgentTemplate.template_slug).asc(),
+                    col(AgentTemplate.version).desc(),
+                )
+                .subquery()
+            )
+            stmt = (
+                delete(AgentTemplateSkill)
+                .where(col(AgentTemplateSkill.skill_id) == skill_id)
+                .where(col(AgentTemplateSkill.template_id).not_in(select(latest.c.id)))
+            )
+            session.exec(stmt)  # type: ignore[call-overload]
+            session.commit()
 
     def get_agent_skills_with_details(
         self, agent_id: UUID

--- a/api/domains/skills/repository.py
+++ b/api/domains/skills/repository.py
@@ -5,7 +5,7 @@ from injector import inject, singleton
 from sqlalchemy import func
 from sqlmodel import Session, col, or_, select
 
-from api.domains.agents.models import AgentSkill, AgentTemplateSkill
+from api.domains.agents.models import Agent, AgentSkill, AgentTemplateSkill
 from api.domains.skills.models import Skill, SkillFilter, SkillSource
 from api.infrastructure.postgres.repository import PostgresRepositoryDelegate
 from api.infrastructure.shared.models import Pagination
@@ -89,7 +89,12 @@ class SkillRepository:
 
     def is_assigned_to_any_agent(self, skill_id: UUID) -> bool:
         with Session(self.delegate.engine) as session:
-            query = select(AgentSkill).where(col(AgentSkill.skill_id) == skill_id)
+            query = (
+                select(AgentSkill)
+                .join(Agent, col(AgentSkill.agent_id) == col(Agent.id))
+                .where(col(AgentSkill.skill_id) == skill_id)
+                .where(col(Agent.deleted_at).is_(None))
+            )
             return session.exec(query).first() is not None
 
     def is_required_by_any_template(self, skill_id: UUID) -> bool:

--- a/api/domains/skills/service.py
+++ b/api/domains/skills/service.py
@@ -170,11 +170,16 @@ class SkillService:
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Skill is currently assigned to one or more agents",
             )
-        if self.repository.is_required_by_any_template(skill_id):
+        blocking_templates = self.repository.get_latest_template_slugs_requiring_skill(
+            skill_id, org_id
+        )
+        if blocking_templates:
+            slugs = ", ".join(blocking_templates)
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="Skill is required by one or more templates and cannot be deleted",
+                detail=f"Skill is required by template(s): {slugs}. Remove it from those templates before deleting.",
             )
+        self.repository.delete_stale_template_skill_refs(skill_id, org_id)
         self.repository.delete(skill)
 
     def get_skill(self, skill_id: UUID, context: CurrentUserContext) -> SkillRead:

--- a/api/domains/skills/service.py
+++ b/api/domains/skills/service.py
@@ -170,6 +170,11 @@ class SkillService:
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Skill is currently assigned to one or more agents",
             )
+        if self.repository.is_required_by_any_template(skill_id):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Skill is required by one or more templates and cannot be deleted",
+            )
         self.repository.delete(skill)
 
     def get_skill(self, skill_id: UUID, context: CurrentUserContext) -> SkillRead:

--- a/api/domains/templates/models.py
+++ b/api/domains/templates/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict, Field, model_validator
 from sqlmodel import Column, Field as SqlField
 
+from api.domains.skills.models import SkillRead
 from api.infrastructure.postgres.models import BaseModel
 
 
@@ -70,6 +71,7 @@ class TemplateRead(PydanticBaseModel):
     heartbeat_md: str
     created_at: datetime
     updated_at: datetime
+    required_skills: list[SkillRead] = Field(default_factory=list)
 
 
 class TemplateCreate(PydanticBaseModel):
@@ -83,6 +85,7 @@ class TemplateCreate(PydanticBaseModel):
     boot_md: str | None = None
     bootstrap_md: str | None = None
     heartbeat_md: str | None = None
+    required_skill_ids: list[UUID] = Field(default_factory=list)
 
 
 class TemplateUpdate(PydanticBaseModel):
@@ -97,6 +100,7 @@ class TemplateUpdate(PydanticBaseModel):
     boot_md: str | None = None
     bootstrap_md: str | None = None
     heartbeat_md: str | None = None
+    required_skill_ids: list[UUID] | None = None
 
     @model_validator(mode="after")
     def validate_not_empty(self) -> "TemplateUpdate":

--- a/api/domains/templates/predefined/__init__.py
+++ b/api/domains/templates/predefined/__init__.py
@@ -26,6 +26,7 @@ class PredefinedTemplate:
     boot_md: str
     bootstrap_md: str
     heartbeat_md: str
+    required_skill_names: tuple[str, ...] = ()
 
 
 PREDEFINED_TEMPLATES: tuple[PredefinedTemplate, ...] = (
@@ -54,6 +55,7 @@ PREDEFINED_TEMPLATES: tuple[PredefinedTemplate, ...] = (
         boot_md=scrum_master.BOOT_MD,
         bootstrap_md=DEFAULT_BOOTSTRAP_MD,
         heartbeat_md=scrum_master.HEARTBEAT_MD,
+        required_skill_names=("Jira", "Confluence"),
     ),
     PredefinedTemplate(
         slug="code-reviewer",

--- a/api/domains/templates/predefined/__init__.py
+++ b/api/domains/templates/predefined/__init__.py
@@ -69,5 +69,6 @@ PREDEFINED_TEMPLATES: tuple[PredefinedTemplate, ...] = (
         boot_md=code_reviewer.BOOT_MD,
         bootstrap_md=DEFAULT_BOOTSTRAP_MD,
         heartbeat_md=code_reviewer.HEARTBEAT_MD,
+        required_skill_names=("GitHub",),
     ),
 )

--- a/api/domains/templates/repository.py
+++ b/api/domains/templates/repository.py
@@ -6,6 +6,8 @@ from sqlalchemy import case, func, or_
 from sqlalchemy.orm import aliased
 from sqlmodel import Session, col, select
 
+from api.domains.agents.models import AgentTemplateSkill
+from api.domains.skills.models import Skill
 from api.domains.templates.models import AgentTemplate, TemplateFilter, TemplateSource
 from api.infrastructure.postgres.repository import PostgresRepositoryDelegate
 from api.infrastructure.shared.models import Pagination
@@ -123,3 +125,95 @@ class TemplateRepository:
     def save_template(self, template: AgentTemplate) -> AgentTemplate:
         self.delegate.save(template)
         return template
+
+    def save_template_skills(self, template_id: UUID, skill_ids: list[UUID]) -> None:
+        with Session(self.delegate.engine) as session:
+            existing_rows = session.exec(
+                select(AgentTemplateSkill).where(
+                    col(AgentTemplateSkill.template_id) == template_id
+                )
+            ).all()
+            existing_ids = {row.skill_id for row in existing_rows}
+            target_ids = set(skill_ids)
+            for row in existing_rows:
+                if row.skill_id not in target_ids:
+                    session.delete(row)
+            for skill_id in target_ids - existing_ids:
+                session.add(
+                    AgentTemplateSkill(template_id=template_id, skill_id=skill_id)
+                )
+            session.commit()
+
+    def get_required_skills(self, template_id: UUID) -> list[Skill]:
+        with Session(self.delegate.engine) as session:
+            query = (
+                select(Skill)
+                .join(
+                    AgentTemplateSkill,
+                    col(AgentTemplateSkill.skill_id) == col(Skill.id),
+                )
+                .where(col(AgentTemplateSkill.template_id) == template_id)
+            )
+            return list(session.exec(query).all())
+
+    def get_required_skill_ids(self, template_id: UUID) -> set[UUID]:
+        with Session(self.delegate.engine) as session:
+            query = select(AgentTemplateSkill.skill_id).where(
+                col(AgentTemplateSkill.template_id) == template_id
+            )
+            return set(session.exec(query).all())
+
+    def get_required_skill_ids_for_templates(
+        self, template_ids: list[UUID]
+    ) -> dict[UUID, set[UUID]]:
+        if not template_ids:
+            return {}
+        with Session(self.delegate.engine) as session:
+            query = select(AgentTemplateSkill).where(
+                col(AgentTemplateSkill.template_id).in_(template_ids)
+            )
+            result: dict[UUID, set[UUID]] = {}
+            for row in session.exec(query).all():
+                result.setdefault(row.template_id, set()).add(row.skill_id)
+            return result
+
+    def is_skill_required_by_any_template(self, skill_id: UUID) -> bool:
+        with Session(self.delegate.engine) as session:
+            query = select(AgentTemplateSkill).where(
+                col(AgentTemplateSkill.skill_id) == skill_id
+            )
+            return session.exec(query).first() is not None
+
+    def get_required_skills_for_templates(
+        self, template_ids: list[UUID]
+    ) -> dict[UUID, list[Skill]]:
+        if not template_ids:
+            return {}
+        with Session(self.delegate.engine) as session:
+            query = (
+                select(AgentTemplateSkill, Skill)
+                .join(Skill, col(AgentTemplateSkill.skill_id) == col(Skill.id))
+                .where(col(AgentTemplateSkill.template_id).in_(template_ids))
+            )
+            result: dict[UUID, list[Skill]] = {}
+            for ats, skill in session.exec(query).all():
+                result.setdefault(ats.template_id, []).append(skill)
+            return result
+
+    def get_template_ids_for_slug_versions(
+        self, org_id: UUID, slug_versions: list[tuple[str, int]]
+    ) -> dict[tuple[str, int], UUID]:
+        if not slug_versions:
+            return {}
+        with Session(self.delegate.engine) as session:
+            result: dict[tuple[str, int], UUID] = {}
+            for slug, version in slug_versions:
+                row = session.exec(
+                    select(AgentTemplate.id)
+                    .where(col(AgentTemplate.organization_id) == org_id)
+                    .where(col(AgentTemplate.template_slug) == slug)
+                    .where(col(AgentTemplate.version) == version)
+                ).first()
+                if row is not None:
+                    result[(slug, version)] = row
+            return result

--- a/api/domains/templates/service.py
+++ b/api/domains/templates/service.py
@@ -218,7 +218,9 @@ class TemplateService:
         template on every start) pick up the change. A lineage the user has edited
         (version > 1) is left untouched so customizations are never clobbered.
         """
-        for predefined, template in zip(PREDEFINED_TEMPLATES, build_predefined_templates(org_id)):
+        for predefined, template in zip(
+            PREDEFINED_TEMPLATES, build_predefined_templates(org_id)
+        ):
             existing = self.repository.get_latest_template(
                 org_id, template.template_slug
             )

--- a/api/domains/templates/service.py
+++ b/api/domains/templates/service.py
@@ -5,6 +5,8 @@ from fastapi import HTTPException, status
 from injector import inject, singleton
 
 from api.domains.auth.models import CurrentUserContext
+from api.domains.skills.models import SkillRead
+from api.domains.skills.repository import SkillRepository
 from api.domains.templates.defaults import (
     DEFAULT_AGENTS_MD,
     DEFAULT_BOOT_MD,
@@ -23,6 +25,7 @@ from api.domains.templates.models import (
     TemplateSource,
     TemplateUpdate,
 )
+from api.domains.templates.predefined import PREDEFINED_TEMPLATES
 from api.domains.templates.repository import TemplateRepository
 from api.domains.templates.seeding import build_predefined_templates
 from api.domains.templates.slug import slugify
@@ -34,9 +37,25 @@ from api.infrastructure.shared.models import PaginatedItems, Pagination
 @dataclass
 class TemplateService:
     repository: TemplateRepository
+    skill_repository: SkillRepository
 
     def _org_id(self, context: CurrentUserContext) -> UUID:
         return context.require_current_user_organization().organization_id
+
+    def _validate_skill_ids(self, skill_ids: list[UUID], org_id: UUID) -> None:
+        accessible = {s.id for s in self.skill_repository.find_accessible_for_org(org_id)}
+        for skill_id in skill_ids:
+            if skill_id not in accessible:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Skill {skill_id} not found",
+                )
+
+    def _with_required_skills(self, read: TemplateRead) -> TemplateRead:
+        skills = self.repository.get_required_skills(read.id)
+        return read.model_copy(
+            update={"required_skills": [SkillRead.model_validate(s) for s in skills]}
+        )
 
     def _get_latest_or_404(self, org_id: UUID, slug: str) -> AgentTemplate:
         template = self.repository.get_latest_template(org_id, slug)
@@ -57,16 +76,27 @@ class TemplateService:
         templates, total = self.repository.find_latest_templates(
             org_id, template_filter, pagination
         )
+        template_ids = [t.id for t in templates]
+        skills_by_template = self.repository.get_required_skills_for_templates(template_ids)
+        items = []
+        for t in templates:
+            read = TemplateRead.model_validate(t)
+            skills = skills_by_template.get(t.id, [])
+            read = read.model_copy(
+                update={"required_skills": [SkillRead.model_validate(s) for s in skills]}
+            )
+            items.append(read)
         return PaginatedItems(
             page=pagination.page,
             page_size=pagination.size,
             total=total,
-            items=[TemplateRead.model_validate(t) for t in templates],
+            items=items,
         )
 
     def get_template(self, slug: str, context: CurrentUserContext) -> TemplateRead:
         org_id = self._org_id(context)
-        return TemplateRead.model_validate(self._get_latest_or_404(org_id, slug))
+        read = TemplateRead.model_validate(self._get_latest_or_404(org_id, slug))
+        return self._with_required_skills(read)
 
     def list_template_versions(
         self, slug: str, context: CurrentUserContext
@@ -78,7 +108,17 @@ class TemplateService:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Template {slug} not found",
             )
-        return [TemplateRead.model_validate(v) for v in versions]
+        template_ids = [v.id for v in versions]
+        skills_by_template = self.repository.get_required_skills_for_templates(template_ids)
+        result = []
+        for v in versions:
+            read = TemplateRead.model_validate(v)
+            skills = skills_by_template.get(v.id, [])
+            read = read.model_copy(
+                update={"required_skills": [SkillRead.model_validate(s) for s in skills]}
+            )
+            result.append(read)
+        return result
 
     def create_template(
         self, data: TemplateCreate, context: CurrentUserContext
@@ -95,6 +135,8 @@ class TemplateService:
                 status_code=status.HTTP_409_CONFLICT,
                 detail=f"A template with slug {slug} already exists",
             )
+        if data.required_skill_ids:
+            self._validate_skill_ids(data.required_skill_ids, org_id)
         template = AgentTemplate(
             organization_id=org_id,
             template_slug=slug,
@@ -112,7 +154,9 @@ class TemplateService:
             heartbeat_md=data.heartbeat_md or DEFAULT_HEARTBEAT_MD,
         )
         self.repository.save_template(template)
-        return TemplateRead.model_validate(template)
+        if data.required_skill_ids:
+            self.repository.save_template_skills(template.id, data.required_skill_ids)
+        return self._with_required_skills(TemplateRead.model_validate(template))
 
     def update_template(
         self, slug: str, data: TemplateUpdate, context: CurrentUserContext
@@ -139,13 +183,31 @@ class TemplateService:
             heartbeat_md=updated.get("heartbeat_md", old.heartbeat_md),
         )
         self.repository.save_template(new_template)
-        return TemplateRead.model_validate(new_template)
+        if data.required_skill_ids is None:
+            resolved_ids = list(self.repository.get_required_skill_ids(old.id))
+        else:
+            if data.required_skill_ids:
+                self._validate_skill_ids(data.required_skill_ids, org_id)
+            resolved_ids = data.required_skill_ids
+        self.repository.save_template_skills(new_template.id, resolved_ids)
+        return self._with_required_skills(TemplateRead.model_validate(new_template))
 
     def seed_predefined_templates(self, org_id: UUID) -> None:
         """Insert pre-defined templates the org doesn't have yet (idempotent)."""
-        for template in build_predefined_templates(org_id):
-            existing = self.repository.get_latest_template(
-                org_id, template.template_slug
-            )
+        template_map = {t.template_slug: t for t in build_predefined_templates(org_id)}
+        for predefined in PREDEFINED_TEMPLATES:
+            existing = self.repository.get_latest_template(org_id, predefined.slug)
             if existing is None:
-                self.repository.save_template(template)
+                self.repository.save_template(template_map[predefined.slug])
+                existing = template_map[predefined.slug]
+            if predefined.required_skill_names:
+                existing_ids = self.repository.get_required_skill_ids(existing.id)
+                if not existing_ids:
+                    skill_ids = [
+                        skill.id
+                        for name in predefined.required_skill_names
+                        if (skill := self.skill_repository.get_by_name_global(name))
+                        is not None
+                    ]
+                    if skill_ids:
+                        self.repository.save_template_skills(existing.id, skill_ids)

--- a/api/domains/templates/service.py
+++ b/api/domains/templates/service.py
@@ -242,13 +242,15 @@ class TemplateService:
                     template.template_slug,
                 )
 
-            if predefined.required_skill_names:
+            if (
+                existing.version == 1
+                and existing.template_source == TemplateSource.PRE_DEFINED
+            ):
+                desired_ids = [
+                    skill.id
+                    for name in predefined.required_skill_names
+                    if (skill := self.skill_repository.get_by_name_global(name))
+                ]
                 existing_ids = self.repository.get_required_skill_ids(existing.id)
-                if not existing_ids:
-                    skill_ids = [
-                        skill.id
-                        for name in predefined.required_skill_names
-                        if (skill := self.skill_repository.get_by_name_global(name))
-                    ]
-                    if skill_ids:
-                        self.repository.save_template_skills(existing.id, skill_ids)
+                if set(desired_ids) != existing_ids:
+                    self.repository.save_template_skills(existing.id, desired_ids)

--- a/api/domains/templates/service.py
+++ b/api/domains/templates/service.py
@@ -199,13 +199,13 @@ class TemplateService:
             bootstrap_md=updated.get("bootstrap_md", old.bootstrap_md),
             heartbeat_md=updated.get("heartbeat_md", old.heartbeat_md),
         )
-        self.repository.save_template(new_template)
         if data.required_skill_ids is None:
             resolved_ids = list(self.repository.get_required_skill_ids(old.id))
         else:
             if data.required_skill_ids:
                 self._validate_skill_ids(data.required_skill_ids, org_id)
             resolved_ids = data.required_skill_ids
+        self.repository.save_template(new_template)
         self.repository.save_template_skills(new_template.id, resolved_ids)
         return self._with_required_skills(TemplateRead.model_validate(new_template))
 

--- a/api/domains/templates/service.py
+++ b/api/domains/templates/service.py
@@ -43,7 +43,9 @@ class TemplateService:
         return context.require_current_user_organization().organization_id
 
     def _validate_skill_ids(self, skill_ids: list[UUID], org_id: UUID) -> None:
-        accessible = {s.id for s in self.skill_repository.find_accessible_for_org(org_id)}
+        accessible = {
+            s.id for s in self.skill_repository.find_accessible_for_org(org_id)
+        }
         for skill_id in skill_ids:
             if skill_id not in accessible:
                 raise HTTPException(
@@ -77,13 +79,17 @@ class TemplateService:
             org_id, template_filter, pagination
         )
         template_ids = [t.id for t in templates]
-        skills_by_template = self.repository.get_required_skills_for_templates(template_ids)
+        skills_by_template = self.repository.get_required_skills_for_templates(
+            template_ids
+        )
         items = []
         for t in templates:
             read = TemplateRead.model_validate(t)
             skills = skills_by_template.get(t.id, [])
             read = read.model_copy(
-                update={"required_skills": [SkillRead.model_validate(s) for s in skills]}
+                update={
+                    "required_skills": [SkillRead.model_validate(s) for s in skills]
+                }
             )
             items.append(read)
         return PaginatedItems(
@@ -109,13 +115,17 @@ class TemplateService:
                 detail=f"Template {slug} not found",
             )
         template_ids = [v.id for v in versions]
-        skills_by_template = self.repository.get_required_skills_for_templates(template_ids)
+        skills_by_template = self.repository.get_required_skills_for_templates(
+            template_ids
+        )
         result = []
         for v in versions:
             read = TemplateRead.model_validate(v)
             skills = skills_by_template.get(v.id, [])
             read = read.model_copy(
-                update={"required_skills": [SkillRead.model_validate(s) for s in skills]}
+                update={
+                    "required_skills": [SkillRead.model_validate(s) for s in skills]
+                }
             )
             result.append(read)
         return result

--- a/api/migrations/versions/e5f6a7b8c9d0_add_agent_template_skill_table.py
+++ b/api/migrations/versions/e5f6a7b8c9d0_add_agent_template_skill_table.py
@@ -38,7 +38,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ix_agent_template_skill_template", table_name="agent_template_skill"
-    )
+    op.drop_index("ix_agent_template_skill_template", table_name="agent_template_skill")
     op.drop_table("agent_template_skill")

--- a/api/migrations/versions/e5f6a7b8c9d0_add_agent_template_skill_table.py
+++ b/api/migrations/versions/e5f6a7b8c9d0_add_agent_template_skill_table.py
@@ -1,0 +1,44 @@
+"""add_agent_template_skill_table
+
+Revision ID: c89367ccd358
+Revises: 032ff9a474bb
+Create Date: 2026-06-26
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c89367ccd358"
+down_revision: Union[str, None] = "032ff9a474bb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_template_skill",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("template_id", sa.UUID(), nullable=False),
+        sa.Column("skill_id", sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["template_id"], ["agent_template.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["skill_id"], ["skill.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("template_id", "skill_id", name="uq_agent_template_skill"),
+    )
+    op.create_index(
+        "ix_agent_template_skill_template", "agent_template_skill", ["template_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_agent_template_skill_template", table_name="agent_template_skill"
+    )
+    op.drop_table("agent_template_skill")

--- a/api/tests/integration/test_agents.py
+++ b/api/tests/integration/test_agents.py
@@ -45,7 +45,7 @@ from api.tests.steps.database import database_is_clean, database_repo_is_ready
 from api.tests.steps.organization import (
     there_is_an_organization_with_user_and_access_token,
 )
-from api.tests.steps.template import there_is_a_template
+from api.tests.steps.template import there_is_a_template, there_is_a_template_skill
 
 _BASE = "/api/v1/agents"
 
@@ -2478,3 +2478,170 @@ def test_start_agent_with_skill_pointer_injects_pointer_into_tools_md():
                     'You can use "Pointed Skill" skill in the ./skills folder'
                 ),
             )
+
+
+# --- template required skills ---
+
+
+def test_create_agent_with_required_skill_marks_it_required():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+        skill_id = str(context.skill.id)
+        payload = {**_VALID_CREATE, "skill_ids": [skill_id]}
+
+        with when("I create an agent including the required skill in skill_ids"):
+            response = client.post(_BASE, json=payload, headers=_auth(context))
+
+        with then("it returns 201 and the skill is marked required=true"):
+            assert_that(response.status_code, equal_to(status.HTTP_201_CREATED))
+            skills = response.json()["skills"]
+            assert_that(len(skills), equal_to(1))
+            assert_that(skills[0]["id"], equal_to(skill_id))
+            assert_that(skills[0]["required"], equal_to(True))
+
+
+def test_create_agent_missing_required_skill_returns_400():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when("I create an agent without including the required skill"):
+            response = client.post(_BASE, json=_VALID_CREATE, headers=_auth(context))
+
+        with then("it returns 400"):
+            assert_that(response.status_code, equal_to(status.HTTP_400_BAD_REQUEST))
+
+
+def test_update_agent_cannot_remove_required_skill_returns_409():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+        skill_id = str(context.skill.id)
+
+        with when("I create an agent with the required skill"):
+            agent = client.post(
+                _BASE,
+                json={**_VALID_CREATE, "skill_ids": [skill_id]},
+                headers=_auth(context),
+            ).json()
+
+        with when("I try to remove the required skill via PATCH"):
+            response = client.patch(
+                f"{_BASE}/{agent['id']}",
+                json={"removed_skill_ids": [skill_id]},
+                headers=_auth(context),
+            )
+
+        with then("it returns 409"):
+            assert_that(response.status_code, equal_to(status.HTTP_409_CONFLICT))
+
+
+def test_update_agent_repin_missing_required_skill_returns_400():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template(slug="with-skill", name="With Skill"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when("I create an agent using a template with no required skills"):
+            agent = client.post(
+                _BASE,
+                json={**_VALID_CREATE, "template_slug": "test-template"},
+                headers=_auth(context),
+            ).json()
+
+        with when("I repin to a template that requires a skill I haven't provided"):
+            response = client.patch(
+                f"{_BASE}/{agent['id']}",
+                json={"template_slug": "with-skill", "template_version": 1},
+                headers=_auth(context),
+            )
+
+        with then("it returns 400"):
+            assert_that(response.status_code, equal_to(status.HTTP_400_BAD_REQUEST))
+
+
+def test_update_agent_repin_with_required_skill_marks_it_required():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template(slug="with-skill", name="With Skill"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+        skill_id = str(context.skill.id)
+
+        with when("I create an agent using a template with no required skills"):
+            agent = client.post(
+                _BASE,
+                json={**_VALID_CREATE, "template_slug": "test-template"},
+                headers=_auth(context),
+            ).json()
+
+        with when("I repin providing the required skill in skill_ids"):
+            response = client.patch(
+                f"{_BASE}/{agent['id']}",
+                json={
+                    "template_slug": "with-skill",
+                    "template_version": 1,
+                    "skill_ids": [skill_id],
+                },
+                headers=_auth(context),
+            )
+
+        with then("it returns 200 and the skill is marked required=true"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            skills = response.json()["skills"]
+            jira = next(s for s in skills if s["id"] == skill_id)
+            assert_that(jira["required"], equal_to(True))
+
+
+def test_list_agents_marks_required_skills():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+        skill_id = str(context.skill.id)
+
+        with when("I create an agent with the required skill"):
+            client.post(
+                _BASE,
+                json={**_VALID_CREATE, "skill_ids": [skill_id]},
+                headers=_auth(context),
+            )
+
+        with when("I list agents"):
+            response = client.get(_BASE, headers=_auth(context))
+
+        with then("the skill appears with required=true in the list response"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            agents = response.json()["items"]
+            assert_that(len(agents), equal_to(1))
+            jira = next(s for s in agents[0]["skills"] if s["id"] == skill_id)
+            assert_that(jira["required"], equal_to(True))

--- a/api/tests/integration/test_skills.py
+++ b/api/tests/integration/test_skills.py
@@ -685,11 +685,34 @@ def test_delete_skill_required_by_template_returns_409():
                 f"{_BASE}/{context.skill.id}", headers=_auth(context)
             )
 
-        with then("it returns 409 with a descriptive message"):
+        with then("it returns 409 naming the blocking template"):
             assert_that(response.status_code, equal_to(status.HTTP_409_CONFLICT))
             assert_that(
                 response.json()["detail"],
                 equal_to(
-                    "Skill is required by one or more templates and cannot be deleted"
+                    "Skill is required by template(s): test-template. Remove it from those templates before deleting."
                 ),
             )
+
+
+def test_delete_skill_no_longer_required_by_latest_template_returns_204():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(),
+            there_is_a_template(slug="test-template", version=1),
+            there_is_a_template_skill(),
+            there_is_a_template(slug="test-template", version=2),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when(
+            "I delete a skill that was required by an old template version but not the latest"
+        ):
+            response = client.delete(
+                f"{_BASE}/{context.skill.id}", headers=_auth(context)
+            )
+
+        with then("it returns 204 because only the latest version is checked"):
+            assert_that(response.status_code, equal_to(status.HTTP_204_NO_CONTENT))

--- a/api/tests/integration/test_skills.py
+++ b/api/tests/integration/test_skills.py
@@ -28,6 +28,7 @@ from api.tests.steps.database import database_is_clean, database_repo_is_ready
 from api.tests.steps.organization import (
     there_is_an_organization_with_user_and_access_token,
 )
+from api.tests.steps.template import there_is_a_template, there_is_a_template_skill
 
 _BASE = "/api/v1/skills"
 
@@ -666,3 +667,29 @@ def test_delete_skill_requires_auth():
 
         with then("request is rejected with 401"):
             assert_that(response.status_code, equal_to(status.HTTP_401_UNAUTHORIZED))
+
+
+def test_delete_skill_required_by_template_returns_409():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(),
+            there_is_a_template(),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when("I try to delete a skill required by a template"):
+            response = client.delete(
+                f"{_BASE}/{context.skill.id}", headers=_auth(context)
+            )
+
+        with then("it returns 409 with a descriptive message"):
+            assert_that(response.status_code, equal_to(status.HTTP_409_CONFLICT))
+            assert_that(
+                response.json()["detail"],
+                equal_to(
+                    "Skill is required by one or more templates and cannot be deleted"
+                ),
+            )

--- a/api/tests/integration/test_templates.py
+++ b/api/tests/integration/test_templates.py
@@ -811,6 +811,52 @@ def test_seed_predefined_templates_does_not_duplicate_skill_rows():
             assert_that(len(skill_ids), equal_to(2))
 
 
+def test_seed_predefined_templates_seeds_code_reviewer_skill():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="GitHub", global_skill=True),
+        ]
+    ) as context:
+        service: TemplateService = context.injector.get(TemplateService)
+        client: TestClient = context.client
+        org_id = context.organization.id
+
+        with when("I seed the org"):
+            service.seed_predefined_templates(org_id)
+
+        with then("code-reviewer has GitHub as a required skill"):
+            response = client.get(f"{_BASE}/code-reviewer", headers=_auth(context))
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            skill_names = [s["name"] for s in response.json()["required_skills"]]
+            assert_that(skill_names, has_items("GitHub"))
+
+
+def test_seed_predefined_templates_refreshes_stale_skills():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="GitHub", global_skill=True),
+        ]
+    ) as context:
+        service: TemplateService = context.injector.get(TemplateService)
+        repository: TemplateRepository = context.injector.get(TemplateRepository)
+        org_id = context.organization.id
+        service.seed_predefined_templates(org_id)
+
+        with when("the seeded skills are cleared from the DB then we reseed"):
+            template = repository.get_latest_template(org_id, "code-reviewer")
+            assert template is not None
+            repository.save_template_skills(template.id, [])
+            service.seed_predefined_templates(org_id)
+
+        with then("the required skills are restored to match the code declaration"):
+            template = repository.get_latest_template(org_id, "code-reviewer")
+            assert template is not None
+            skill_ids = repository.get_required_skill_ids(template.id)
+            assert_that(len(skill_ids), equal_to(1))
+
+
 def test_predefined_content_keeps_raw_placeholders():
     with given(_GIVEN) as context:
         service: TemplateService = context.injector.get(TemplateService)

--- a/api/tests/integration/test_templates.py
+++ b/api/tests/integration/test_templates.py
@@ -3,6 +3,7 @@ from hamcrest import (
     assert_that,
     contains_string,
     equal_to,
+    has_items,
     is_not,
     none,
 )
@@ -26,13 +27,14 @@ from api.tests.steps.agent import (
     TEST_ENCRYPTION_KEY,
     MockK8sModule,
     MockLiteLLMModule,
+    there_is_a_skill,
     use_org_for_auth,
 )
 from api.tests.steps.database import database_is_clean, database_repo_is_ready
 from api.tests.steps.organization import (
     there_is_an_organization_with_user_and_access_token,
 )
-from api.tests.steps.template import there_is_a_template
+from api.tests.steps.template import there_is_a_template, there_is_a_template_skill
 
 _BASE = "/api/v1/templates"
 _AGENTS_BASE = "/api/v1/agents"
@@ -189,6 +191,28 @@ def test_list_templates_no_auth_returns_401():
             assert_that(response.status_code, equal_to(status.HTTP_401_UNAUTHORIZED))
 
 
+def test_list_templates_includes_required_skills():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template(slug="alpha", name="Alpha"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when("I list templates"):
+            response = client.get(_BASE, headers=_auth(context))
+
+        with then("the template includes its required skills"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            items = response.json()["items"]
+            assert_that(len(items), equal_to(1))
+            skill_names = [s["name"] for s in items[0]["required_skills"]]
+            assert_that(skill_names, equal_to(["Jira"]))
+
+
 # --- get ---
 
 
@@ -267,6 +291,29 @@ def test_list_template_versions_no_auth_returns_401():
 
         with then("it returns 401"):
             assert_that(response.status_code, equal_to(status.HTTP_401_UNAUTHORIZED))
+
+
+def test_list_template_versions_includes_required_skills():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template(slug="alpha", name="Alpha", version=1),
+            there_is_a_template_skill(),
+            there_is_a_template(slug="alpha", name="Alpha", version=2),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when("I list versions of the template"):
+            response = client.get(f"{_BASE}/alpha/versions", headers=_auth(context))
+
+        with then("v1 includes the required skill; v2 has none (new version, no inherit via API)"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            versions = {v["version"]: v for v in response.json()}
+            assert_that(len(versions[1]["required_skills"]), equal_to(1))
+            assert_that(versions[1]["required_skills"][0]["name"], equal_to("Jira"))
+            assert_that(versions[2]["required_skills"], equal_to([]))
 
 
 # --- create ---
@@ -364,6 +411,52 @@ def test_create_template_empty_name_returns_422():
             assert_that(
                 response.status_code, equal_to(status.HTTP_422_UNPROCESSABLE_ENTITY)
             )
+
+
+def test_create_template_with_required_skills_stores_them():
+    with given([*_GIVEN, there_is_a_skill(name="Jira")]) as context:
+        client: TestClient = context.client
+
+        with when("I create a template with a required skill"):
+            response = client.post(
+                _BASE,
+                json={
+                    "template_name": "My Template",
+                    "required_skill_ids": [str(context.skill.id)],
+                },
+                headers=_auth(context),
+            )
+
+        with then("it returns 201 with required_skills populated"):
+            assert_that(response.status_code, equal_to(status.HTTP_201_CREATED))
+            body = response.json()
+            assert_that(len(body["required_skills"]), equal_to(1))
+            assert_that(body["required_skills"][0]["id"], equal_to(str(context.skill.id)))
+            assert_that(body["required_skills"][0]["name"], equal_to("Jira"))
+
+        with then("GET also returns the required skill"):
+            get_resp = client.get(f"{_BASE}/my-template", headers=_auth(context))
+            assert_that(len(get_resp.json()["required_skills"]), equal_to(1))
+
+
+def test_create_template_with_unknown_skill_returns_404():
+    from uuid import uuid4
+
+    with given(_GIVEN) as context:
+        client: TestClient = context.client
+
+        with when("I create a template with a non-existent skill ID"):
+            response = client.post(
+                _BASE,
+                json={
+                    "template_name": "My Template",
+                    "required_skill_ids": [str(uuid4())],
+                },
+                headers=_auth(context),
+            )
+
+        with then("it returns 404"):
+            assert_that(response.status_code, equal_to(status.HTTP_404_NOT_FOUND))
 
 
 # --- update ---
@@ -501,6 +594,85 @@ def test_update_template_empty_body_returns_422():
             )
 
 
+def test_update_template_inherits_skills_by_default():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template(slug="alpha", name="Alpha"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when("I update the template without specifying required_skill_ids"):
+            response = client.patch(
+                f"{_BASE}/alpha",
+                json={"soul_md": "# Updated"},
+                headers=_auth(context),
+            )
+
+        with then("the new version carries over the required skills from v1"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            body = response.json()
+            assert_that(body["version"], equal_to(2))
+            assert_that(len(body["required_skills"]), equal_to(1))
+            assert_that(body["required_skills"][0]["name"], equal_to("Jira"))
+
+
+def test_update_template_replaces_skills():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template(slug="alpha", name="Alpha"),
+            there_is_a_template_skill(),
+            there_is_a_skill(name="Confluence"),
+        ]
+    ) as context:
+        client: TestClient = context.client
+        confluence_id = str(context.skill.id)
+
+        with when("I update the template replacing required skills"):
+            response = client.patch(
+                f"{_BASE}/alpha",
+                json={"soul_md": "# Updated", "required_skill_ids": [confluence_id]},
+                headers=_auth(context),
+            )
+
+        with then("the new version has only the replacement skill"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            body = response.json()
+            assert_that(body["version"], equal_to(2))
+            assert_that(len(body["required_skills"]), equal_to(1))
+            assert_that(body["required_skills"][0]["name"], equal_to("Confluence"))
+
+
+def test_update_template_clears_skills():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira"),
+            there_is_a_template(slug="alpha", name="Alpha"),
+            there_is_a_template_skill(),
+        ]
+    ) as context:
+        client: TestClient = context.client
+
+        with when("I update the template clearing required skills"):
+            response = client.patch(
+                f"{_BASE}/alpha",
+                json={"soul_md": "# Updated", "required_skill_ids": []},
+                headers=_auth(context),
+            )
+
+        with then("the new version has no required skills"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            body = response.json()
+            assert_that(body["version"], equal_to(2))
+            assert_that(body["required_skills"], equal_to([]))
+
+
 # --- seeding ---
 
 
@@ -566,6 +738,51 @@ def test_seed_does_not_clobber_edited_predefined_template():
             assert latest is not None
             assert_that(latest.version, equal_to(2))
             assert_that(latest.soul_md, equal_to("# Edited Soul"))
+
+
+def test_seed_predefined_templates_seeds_scrum_master_skills():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira", global_skill=True),
+            there_is_a_skill(name="Confluence", global_skill=True),
+        ]
+    ) as context:
+        service: TemplateService = context.injector.get(TemplateService)
+        client: TestClient = context.client
+        org_id = context.organization.id
+
+        with when("I seed the org"):
+            service.seed_predefined_templates(org_id)
+
+        with then("scrum-master has Jira and Confluence as required skills"):
+            response = client.get(f"{_BASE}/scrum-master", headers=_auth(context))
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            skill_names = [s["name"] for s in response.json()["required_skills"]]
+            assert_that(skill_names, has_items("Jira", "Confluence"))
+
+
+def test_seed_predefined_templates_does_not_duplicate_skill_rows():
+    with given(
+        [
+            *_GIVEN,
+            there_is_a_skill(name="Jira", global_skill=True),
+            there_is_a_skill(name="Confluence", global_skill=True),
+        ]
+    ) as context:
+        service: TemplateService = context.injector.get(TemplateService)
+        repository: TemplateRepository = context.injector.get(TemplateRepository)
+        org_id = context.organization.id
+
+        with when("I seed twice"):
+            service.seed_predefined_templates(org_id)
+            service.seed_predefined_templates(org_id)
+
+        with then("scrum-master still has exactly two required skills"):
+            template = repository.get_latest_template(org_id, "scrum-master")
+            assert template is not None
+            skill_ids = repository.get_required_skill_ids(template.id)
+            assert_that(len(skill_ids), equal_to(2))
 
 
 def test_predefined_content_keeps_raw_placeholders():

--- a/api/tests/integration/test_templates.py
+++ b/api/tests/integration/test_templates.py
@@ -308,7 +308,9 @@ def test_list_template_versions_includes_required_skills():
         with when("I list versions of the template"):
             response = client.get(f"{_BASE}/alpha/versions", headers=_auth(context))
 
-        with then("v1 includes the required skill; v2 has none (new version, no inherit via API)"):
+        with then(
+            "v1 includes the required skill; v2 has none (new version, no inherit via API)"
+        ):
             assert_that(response.status_code, equal_to(status.HTTP_200_OK))
             versions = {v["version"]: v for v in response.json()}
             assert_that(len(versions[1]["required_skills"]), equal_to(1))
@@ -431,7 +433,9 @@ def test_create_template_with_required_skills_stores_them():
             assert_that(response.status_code, equal_to(status.HTTP_201_CREATED))
             body = response.json()
             assert_that(len(body["required_skills"]), equal_to(1))
-            assert_that(body["required_skills"][0]["id"], equal_to(str(context.skill.id)))
+            assert_that(
+                body["required_skills"][0]["id"], equal_to(str(context.skill.id))
+            )
             assert_that(body["required_skills"][0]["name"], equal_to("Jira"))
 
         with then("GET also returns the required skill"):

--- a/api/tests/steps/template.py
+++ b/api/tests/steps/template.py
@@ -51,3 +51,28 @@ def there_is_a_template(
         context.template = template
 
     return step
+
+
+def there_is_a_template_skill():
+    """Attach context.skill to context.template as a required skill."""
+
+    def step(context):
+        from sqlmodel import Session
+
+        from api.domains.agents.models import AgentTemplateSkill
+        from api.infrastructure.postgres.repository import PostgresRepositoryDelegate
+
+        delegate: PostgresRepositoryDelegate = context.injector.get(
+            PostgresRepositoryDelegate
+        )
+        with Session(delegate.engine) as session:
+            session.add(
+                AgentTemplateSkill(
+                    template_id=context.template.id,
+                    skill_id=context.skill.id,
+                )
+            )
+            session.commit()
+        context.template_skill = (context.template.id, context.skill.id)
+
+    return step

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
 version: 0.4.0
-appVersion: "0.20.0"
+appVersion: "0.21.0"

--- a/helm/agentfarm-ui/Chart.yaml
+++ b/helm/agentfarm-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-ui
 description: Next.js frontend for agent-farm
 version: 0.4.0
-appVersion: "0.19.0"
+appVersion: "0.20.0"

--- a/ui/src/features/agents/components/agent-skills-tab.tsx
+++ b/ui/src/features/agents/components/agent-skills-tab.tsx
@@ -5,6 +5,7 @@ import { useDebouncedValue } from "@tanstack/react-pacer";
 
 import { AppErrorState } from "@/components/app-error-state";
 import { SearchIcon } from "@/components/icons";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useSkills } from "@/features/skills/hooks/use-skills";
 import { SKILL_PROVIDER_LABELS } from "@/features/skills/utils";
 import { SkillSourceBadge } from "@/features/skills/components/skill-drawer";
@@ -451,14 +452,37 @@ function AssignedSkillRow({
           {skill.name}
         </span>
         <SkillSourceBadge source={skill.source} />
+        {skill.required && (
+          <span
+            className="text-[0.6875rem] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full"
+            style={{ color: "var(--ink-3)", background: "var(--line)" }}
+          >
+            Required
+          </span>
+        )}
       </div>
-      <button
-        className="af-btn af-btn-sm af-btn-ghost"
-        disabled={isRunning}
-        onClick={onRemove}
-      >
-        Remove
-      </button>
+      {skill.required ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span>
+                <button className="af-btn af-btn-sm af-btn-ghost" disabled>
+                  Remove
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Required by template</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <button
+          className="af-btn af-btn-sm af-btn-ghost"
+          disabled={isRunning}
+          onClick={onRemove}
+        >
+          Remove
+        </button>
+      )}
     </div>
   );
 }

--- a/ui/src/features/agents/components/config-drawer.tsx
+++ b/ui/src/features/agents/components/config-drawer.tsx
@@ -81,7 +81,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
   const [secretDrafts, setSecretDrafts] = useState<IntegrationDraft[]>([]);
   const [removedProviders, setRemovedProviders] = useState<string[]>([]);
   const [savedSecrets, setSavedSecrets] = useState(false);
-  const [errorSection, setErrorSection] = useState<"tokens" | "secrets" | null>(null);
+  const [errorSection, setErrorSection] = useState<"tokens" | "secrets" | "template" | null>(null);
   const [pendingSection, setPendingSection] = useState<"tokens" | "secrets" | null>(null);
   const [repinSecretDrafts, setRepinSecretDrafts] = useState<IntegrationDraft[]>([]);
   const [repinVisible, setRepinVisible] = useState<Record<string, boolean>>({});
@@ -156,6 +156,8 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
 
   async function handleApplyTemplate() {
     if (!repinSlug || resolvedRepinVersion == null) return;
+    updateAgent.reset();
+    setErrorSection(null);
     try {
       await updateAgent.mutateAsync({
         agentId: agent.id,
@@ -178,7 +180,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
       setSavedTemplate(true);
       setTimeout(() => setSavedTemplate(false), 2500);
     } catch {
-      // error displayed via updateAgent.error
+      setErrorSection("template");
     }
   }
 
@@ -240,6 +242,12 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
     }
   }
 
+  function handleTabChange(newTab: TabKey) {
+    updateAgent.reset();
+    setErrorSection(null);
+    onTabChange(newTab);
+  }
+
   async function handleRetire() {
     try {
       await deleteAgent.mutateAsync(agent.id);
@@ -287,7 +295,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
               className="af-drawer-tab"
               data-active={tab === k}
               disabled={!enabled}
-              onClick={() => enabled && onTabChange(k as TabKey)}
+              onClick={() => enabled && handleTabChange(k as TabKey)}
               style={!enabled ? { opacity: 0.35, cursor: "default" } : undefined}
             >
               {l}
@@ -583,7 +591,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
                 >
                   {savedTemplate ? "Applied!" : "Apply template"}
                 </button>
-                {updateAgent.error && (
+                {updateAgent.error && errorSection === "template" && (
                   <span className="text-xs" style={{ color: "var(--err)" }}>
                     {updateAgent.error instanceof Error ? updateAgent.error.message : "Update failed"}
                   </span>

--- a/ui/src/features/agents/components/config-drawer.tsx
+++ b/ui/src/features/agents/components/config-drawer.tsx
@@ -2,18 +2,19 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import type { Agent } from "../schemas";
+import type { Agent, AgentAssignedSkill } from "../schemas";
 import { useAgentTemplate } from "../hooks/use-agent-template";
 import { useUpdateAgent } from "../hooks/use-update-agent";
 import { useDeleteAgent } from "../hooks/use-delete-agent";
 import { XIcon, LockIcon } from "@/components/icons";
-import { TokenInput } from "./hire-dialog-primitives";
+import { FormField, TokenInput } from "./hire-dialog-primitives";
 import { IntegrationsStep, TemplateSourceBadge, VersionSelect } from "./hire-dialog-steps";
 import { ModelSelect } from "./model-select";
 import {
   expandGithubContent,
   getIntegrationProvider,
   hasIncompleteIntegration,
+  parseGithubRepoUrl,
   type IntegrationDraft,
 } from "../integrations";
 import { SlackConfigPanel } from "./slack-config-panel";
@@ -82,6 +83,8 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
   const [savedSecrets, setSavedSecrets] = useState(false);
   const [errorSection, setErrorSection] = useState<"tokens" | "secrets" | null>(null);
   const [pendingSection, setPendingSection] = useState<"tokens" | "secrets" | null>(null);
+  const [repinSecretDrafts, setRepinSecretDrafts] = useState<IntegrationDraft[]>([]);
+  const [repinVisible, setRepinVisible] = useState<Record<string, boolean>>({});
 
   const tabs = getTabs(agent.platform);
   // Clamp the URL-provided tab to one that's actually reachable for this agent
@@ -107,6 +110,40 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
     repinSlug === agent.templateSlug &&
     resolvedRepinVersion === agent.templateVersion;
 
+  // Required skills for the currently selected re-pin version.
+  const newTemplateRequiredSkills: AgentAssignedSkill[] =
+    repinSlug != null && resolvedRepinVersion != null
+      ? (repinVersions.find((v) => v.version === resolvedRepinVersion)?.requiredSkills ?? [])
+      : [];
+
+  const existingSecretProviders = new Set((agent.secrets ?? []).map((s) => s.provider));
+
+  // Required providers not already covered by the agent's existing secrets.
+  const newRequiredProviderIds = [
+    ...new Set(
+      newTemplateRequiredSkills
+        .flatMap((s) => s.requiredProviders)
+        .filter((p) => !existingSecretProviders.has(p)),
+    ),
+  ];
+
+  // Always include a draft entry for every newly required provider so forms render.
+  const effectiveRepinSecretDrafts: IntegrationDraft[] = newRequiredProviderIds.map(
+    (p) => repinSecretDrafts.find((d) => d.provider === p) ?? { provider: p, content: {} },
+  );
+
+  function setRepinSecretField(provider: string, key: string, value: string) {
+    setRepinSecretDrafts((prev) => {
+      const existing = prev.find((d) => d.provider === provider);
+      if (existing) {
+        return prev.map((d) =>
+          d.provider === provider ? { ...d, content: { ...d.content, [key]: value } } : d,
+        );
+      }
+      return [...prev, { provider, content: { [key]: value } }];
+    });
+  }
+
   async function handleSave() {
     try {
       await updateAgent.mutateAsync({ agentId: agent.id, name, model });
@@ -124,9 +161,20 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
         agentId: agent.id,
         templateSlug: repinSlug,
         templateVersion: resolvedRepinVersion,
+        skillIds: newTemplateRequiredSkills.map((s) => s.id),
+        ...(effectiveRepinSecretDrafts.length > 0
+          ? {
+              secrets: effectiveRepinSecretDrafts.map((d) => ({
+                provider: d.provider,
+                content: d.provider === "github" ? expandGithubContent(d.content) : d.content,
+              })),
+            }
+          : {}),
       });
       setRepinSlug(null);
       setRepinVersion(null);
+      setRepinSecretDrafts([]);
+      setRepinVisible({});
       setSavedTemplate(true);
       setTimeout(() => setSavedTemplate(false), 2500);
     } catch {
@@ -346,7 +394,12 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
                           borderBottom: "1px solid var(--line)",
                           background: selected ? "var(--bg-soft)" : "transparent",
                         }}
-                        onClick={() => { setRepinSlug(t.templateSlug); setRepinVersion(null); }}
+                        onClick={() => {
+                          setRepinSlug(t.templateSlug);
+                          setRepinVersion(null);
+                          setRepinSecretDrafts([]);
+                          setRepinVisible({});
+                        }}
                       >
                         <span className="font-medium text-[0.844rem]" style={{ color: "var(--ink)" }}>
                           {t.templateName}
@@ -373,7 +426,11 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
                       <VersionSelect
                         versions={repinVersions}
                         selectedVersion={resolvedRepinVersion}
-                        onChange={setRepinVersion}
+                        onChange={(v) => {
+                          setRepinVersion(v);
+                          setRepinSecretDrafts([]);
+                          setRepinVisible({});
+                        }}
                         disabled={isRunning}
                       />
                     </div>
@@ -381,10 +438,146 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
                 </div>
               )}
 
+              {newTemplateRequiredSkills.length > 0 && (
+                <div className="flex flex-col gap-3">
+                  <div className="font-medium text-[0.844rem]" style={{ color: "var(--ink)" }}>
+                    Required skills
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    {newTemplateRequiredSkills.map((skill) => {
+                      const missingProviders = skill.requiredProviders.filter(
+                        (p) => !existingSecretProviders.has(p),
+                      );
+                      return (
+                        <div
+                          key={skill.id}
+                          className="flex items-center gap-2 px-3.5 py-2.5 rounded-2xl text-[0.8125rem]"
+                          style={{ border: "1px solid var(--line)", background: "var(--bg-soft)" }}
+                        >
+                          <span className="font-medium flex-1" style={{ color: "var(--ink)" }}>
+                            {skill.name}
+                          </span>
+                          {missingProviders.length > 0 && (
+                            <span style={{ color: "var(--ink-4)" }}>
+                              · needs {missingProviders
+                                .map((p) => getIntegrationProvider(p)?.label ?? p)
+                                .join(", ")} credential
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {newRequiredProviderIds.map((providerId) => {
+                    const providerSpec = getIntegrationProvider(providerId);
+                    const draft = effectiveRepinSecretDrafts.find((d) => d.provider === providerId);
+                    if (!draft) return null;
+
+                    if (!providerSpec) {
+                      return (
+                        <div
+                          key={providerId}
+                          className="px-4 py-3 rounded-2xl text-[0.8125rem]"
+                          style={{ border: "1px solid var(--line)", background: "var(--bg-soft)", color: "var(--ink-3)" }}
+                        >
+                          <span className="font-medium" style={{ color: "var(--ink)" }}>
+                            {providerId}
+                          </span>{" "}
+                          — not yet configurable from the UI.
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <div
+                        key={providerId}
+                        className="flex flex-col gap-3.5 p-4 rounded-2xl"
+                        style={{ border: "1px solid var(--line)", background: "var(--bg-soft)" }}
+                      >
+                        <div className="font-semibold text-[0.844rem]" style={{ color: "var(--ink)" }}>
+                          {providerSpec.label}
+                        </div>
+                        {providerSpec.fields.map((field) => {
+                          const value = draft.content[field.key] ?? "";
+                          const label = field.required ? field.label : `${field.label} (optional)`;
+                          if (field.type === "secret") {
+                            const vkey = `${providerId}:${field.key}`;
+                            return (
+                              <FormField key={field.key} label={label} hint={field.hint}>
+                                <TokenInput
+                                  value={value}
+                                  onChange={(v) => setRepinSecretField(providerId, field.key, v)}
+                                  visible={!!repinVisible[vkey]}
+                                  onToggle={() =>
+                                    setRepinVisible((s) => ({ ...s, [vkey]: !s[vkey] }))
+                                  }
+                                  placeholder={field.placeholder}
+                                  disabled={isRunning}
+                                />
+                              </FormField>
+                            );
+                          }
+                          if (field.type === "repo-url") {
+                            const parsed = parseGithubRepoUrl(value);
+                            const invalid = value.length > 0 && !parsed;
+                            return (
+                              <FormField key={field.key} label={label} hint={field.hint}>
+                                <input
+                                  className={`af-input${invalid ? " border-red-400" : ""}`}
+                                  value={value}
+                                  onChange={(e) =>
+                                    setRepinSecretField(providerId, field.key, e.target.value)
+                                  }
+                                  placeholder={field.placeholder}
+                                  autoComplete="off"
+                                  disabled={isRunning}
+                                />
+                                {parsed && (
+                                  <p className="text-[0.75rem] mt-1" style={{ color: "var(--ink-3)" }}>
+                                    owner: <strong>{parsed.owner}</strong> · repo:{" "}
+                                    <strong>{parsed.repo}</strong>
+                                  </p>
+                                )}
+                                {invalid && (
+                                  <p className="text-[0.75rem] mt-1 text-red-500">
+                                    Must be a valid GitHub URL, e.g. https://github.com/owner/repo.git
+                                  </p>
+                                )}
+                              </FormField>
+                            );
+                          }
+                          return (
+                            <FormField key={field.key} label={label} hint={field.hint}>
+                              <input
+                                className="af-input"
+                                value={value}
+                                onChange={(e) =>
+                                  setRepinSecretField(providerId, field.key, e.target.value)
+                                }
+                                placeholder={field.placeholder}
+                                autoComplete="off"
+                                disabled={isRunning}
+                              />
+                            </FormField>
+                          );
+                        })}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
               <div className="flex gap-2 items-center">
                 <button
                   className="af-btn af-btn-sm"
-                  disabled={isRunning || updateAgent.isPending || !repinSlug || repinIsNoop}
+                  disabled={
+                    isRunning ||
+                    updateAgent.isPending ||
+                    !repinSlug ||
+                    repinIsNoop ||
+                    hasIncompleteIntegration(effectiveRepinSecretDrafts)
+                  }
                   title={isRunning ? "Stop the agent before changing its template" : undefined}
                   onClick={() => { void handleApplyTemplate(); }}
                 >

--- a/ui/src/features/agents/components/hire-dialog-steps.tsx
+++ b/ui/src/features/agents/components/hire-dialog-steps.tsx
@@ -1099,6 +1099,12 @@ export function SkillsStep({
 
   const totalPages = Math.max(1, Math.ceil(total / HIRE_DIALOG_PAGE_SIZE));
 
+  const requiredSkillIds = new Set(templateRequiredSkills.map((s) => s.id));
+  const orderedSkills = [
+    ...skills.filter((s) => requiredSkillIds.has(s.id)),
+    ...skills.filter((s) => !requiredSkillIds.has(s.id)),
+  ];
+
   // Track full Skill objects for selected skills so we can compute requiredProviders
   // across pages. Users can only toggle visible skills, so this stays in sync.
   const [selectedSkillObjects, setSelectedSkillObjects] = useState<Skill[]>([]);
@@ -1190,8 +1196,8 @@ export function SkillsStep({
         )}
         {!isLoading && skills.length > 0 && (
           <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3">
-            {skills.map((skill) => {
-              const isRequired = templateRequiredSkills.some((s) => s.id === skill.id);
+            {orderedSkills.map((skill) => {
+              const isRequired = requiredSkillIds.has(skill.id);
               const selected = isRequired || selectedSkillIds.includes(skill.id);
               return (
                 <div

--- a/ui/src/features/agents/components/hire-dialog-steps.tsx
+++ b/ui/src/features/agents/components/hire-dialog-steps.tsx
@@ -21,7 +21,7 @@ import {
   parseGithubRepoUrl,
   type IntegrationDraft,
 } from "../integrations";
-import type { AgentTemplateRead } from "../schemas";
+import type { AgentAssignedSkill, AgentTemplateRead } from "../schemas";
 import { useTemplates } from "../hooks/use-templates";
 import { ChoiceCard, FormField, NextStep, TokenInput } from "./hire-dialog-primitives";
 import { ModelSelect } from "./model-select";
@@ -1079,11 +1079,13 @@ export function SkillsStep({
   skillCredentials,
   onSkillIdsChange,
   onSkillCredentialsChange,
+  templateRequiredSkills = [],
 }: {
   selectedSkillIds: string[];
   skillCredentials: IntegrationDraft[];
   onSkillIdsChange: (ids: string[]) => void;
   onSkillCredentialsChange: (drafts: IntegrationDraft[]) => void;
+  templateRequiredSkills?: AgentAssignedSkill[];
 }) {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
@@ -1101,7 +1103,10 @@ export function SkillsStep({
   // across pages. Users can only toggle visible skills, so this stays in sync.
   const [selectedSkillObjects, setSelectedSkillObjects] = useState<Skill[]>([]);
   const requiredProviderIds: string[] = [
-    ...new Set(selectedSkillObjects.flatMap((s) => s.requiredProviders)),
+    ...new Set([
+      ...templateRequiredSkills.flatMap((s) => s.requiredProviders),
+      ...selectedSkillObjects.flatMap((s) => s.requiredProviders),
+    ]),
   ];
 
   function handleSearchChange(value: string) {
@@ -1118,7 +1123,10 @@ export function SkillsStep({
       ? selectedSkillObjects.filter((s) => s.id !== skill.id)
       : [...selectedSkillObjects, skill];
 
-    const newRequired = new Set(newObjects.flatMap((s) => s.requiredProviders));
+    const newRequired = new Set([
+      ...templateRequiredSkills.flatMap((s) => s.requiredProviders),
+      ...newObjects.flatMap((s) => s.requiredProviders),
+    ]);
     const newCreds = skillCredentials.filter((c) => newRequired.has(c.provider));
     for (const p of newRequired) {
       if (!newCreds.find((c) => c.provider === p)) {
@@ -1183,16 +1191,18 @@ export function SkillsStep({
         {!isLoading && skills.length > 0 && (
           <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3">
             {skills.map((skill) => {
-              const selected = selectedSkillIds.includes(skill.id);
+              const isRequired = templateRequiredSkills.some((s) => s.id === skill.id);
+              const selected = isRequired || selectedSkillIds.includes(skill.id);
               return (
                 <div
                   key={skill.id}
-                  className="flex flex-col gap-1.5 p-4 rounded-2xl cursor-default transition-colors min-h-[4.5rem]"
+                  className="flex flex-col gap-1.5 p-4 rounded-2xl transition-colors min-h-[4.5rem]"
                   style={{
+                    cursor: isRequired ? "default" : "pointer",
                     border: selected ? "1.5px solid var(--ink)" : "1.5px solid var(--line)",
                     background: selected ? "var(--bg-soft)" : "var(--bg-elev)",
                   }}
-                  onClick={() => toggleSkill(skill)}
+                  onClick={() => { if (!isRequired) toggleSkill(skill); }}
                 >
                   <div className="flex items-center justify-between gap-2">
                     <div className="font-semibold text-[0.844rem]" style={{ color: "var(--ink)" }}>
@@ -1200,6 +1210,11 @@ export function SkillsStep({
                     </div>
                     <SkillSourceBadge source={skill.source} />
                   </div>
+                  {isRequired && (
+                    <div className="text-[0.6875rem]" style={{ color: "var(--ink-3)" }}>
+                      Required by template
+                    </div>
+                  )}
                   {skill.requiredProviders.length > 0 && (
                     <div className="text-[0.75rem]" style={{ color: "var(--ink-4)" }}>
                       {skill.requiredProviders.map((p) => SKILL_PROVIDER_LABELS[p] ?? p).join(", ")}

--- a/ui/src/features/agents/components/hire-dialog.tsx
+++ b/ui/src/features/agents/components/hire-dialog.tsx
@@ -260,7 +260,10 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
         agentType,
         templateSlug: effectiveTemplate.templateSlug,
         ...(resolvedVersion != null ? { templateVersion: resolvedVersion } : {}),
-        skillIds: selectedSkillIds,
+        skillIds: [
+          ...(versionTemplate?.requiredSkills?.map((s) => s.id) ?? []),
+          ...selectedSkillIds,
+        ],
         secrets: skillCredentials.map((c) => ({
           provider: c.provider,
           content: c.provider === "github" ? expandGithubContent(c.content) : c.content,
@@ -597,6 +600,7 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
             skillCredentials={skillCredentials}
             onSkillIdsChange={setSelectedSkillIds}
             onSkillCredentialsChange={setSkillCredentials}
+            templateRequiredSkills={versionTemplate?.requiredSkills ?? []}
           />
         )}
       </div>
@@ -684,7 +688,21 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
           <button
             className="af-btn af-btn-primary af-btn-lg"
             disabled={!name.trim()}
-            onClick={() => setStep("skills")}
+            onClick={() => {
+              // Pre-populate credential drafts for template required skills.
+              const requiredProviders = [
+                ...new Set(
+                  (versionTemplate?.requiredSkills ?? []).flatMap((s) => s.requiredProviders),
+                ),
+              ];
+              setSkillCredentials((prev) => {
+                const existing = new Set(prev.map((c) => c.provider));
+                const toAdd = requiredProviders.filter((p) => !existing.has(p));
+                if (toAdd.length === 0) return prev;
+                return [...prev, ...toAdd.map((p) => ({ provider: p, content: {} }))];
+              });
+              setStep("skills");
+            }}
           >
             Continue
           </button>

--- a/ui/src/features/agents/components/template-drawer.tsx
+++ b/ui/src/features/agents/components/template-drawer.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { XIcon } from "@/components/icons";
+import { useDebouncedValue } from "@tanstack/react-pacer";
+import { SearchIcon, XIcon } from "@/components/icons";
+import { useSkills } from "@/features/skills/hooks/use-skills";
+import { SkillSourceBadge } from "@/features/skills/components/skill-drawer";
+import { SKILL_PROVIDER_LABELS } from "@/features/skills/utils";
 import { useTemplateVersions } from "../hooks/use-template-versions";
 import { useCreateTemplate } from "../hooks/use-create-template";
 import { useUpdateTemplate } from "../hooks/use-update-template";
@@ -40,6 +44,8 @@ function filesFrom(template: AgentTemplateRead): TemplateFiles {
   };
 }
 
+type SkillEntry = { id: string; name: string; source: string; requiredProviders: string[] };
+
 function deriveSlug(name: string): string {
   return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
@@ -66,6 +72,13 @@ export function TemplateDrawer({
   const [file, setFile] = useState<TemplateFileKey>("soulMd");
   const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
   const [savedVersion, setSavedVersion] = useState<number | null>(null);
+  const [selectedSkillDetails, setSelectedSkillDetails] = useState<SkillEntry[]>([]);
+  const [skillSearch, setSkillSearch] = useState("");
+  const [debouncedSkillSearch] = useDebouncedValue(skillSearch, { wait: 300 });
+
+  const { skills, isLoading: skillsLoading } = useSkills({ search: debouncedSkillSearch || undefined, pageSize: 100 });
+  const requiredSkillIds = selectedSkillDetails.map((s) => s.id);
+  const unselectedSkills = skills.filter((s) => !requiredSkillIds.includes(s.id));
 
   // The version currently being displayed/edited (defaults to latest).
   const resolvedVersion = selectedVersion ?? versions[0]?.version ?? null;
@@ -83,9 +96,26 @@ export function TemplateDrawer({
     if (current) {
       setFiles(filesFrom(current));
       setDescription(current.description ?? "");
+      setSelectedSkillDetails(
+        current.requiredSkills.map((s) => ({
+          id: s.id,
+          name: s.name,
+          source: s.source,
+          requiredProviders: s.requiredProviders,
+        })),
+      );
     }
+    setSkillSearch("");
     setSavedVersion(null);
     setEditing(true);
+  }
+
+  function addRequiredSkill(skill: SkillEntry) {
+    setSelectedSkillDetails((prev) => [...prev, skill]);
+  }
+
+  function removeRequiredSkill(id: string) {
+    setSelectedSkillDetails((prev) => prev.filter((s) => s.id !== id));
   }
 
   async function handleSave() {
@@ -93,12 +123,12 @@ export function TemplateDrawer({
     updateTemplate.reset();
     try {
       if (mode === "create") {
-        await createTemplate.mutateAsync({ templateName: name, description: description || null, ...files });
+        await createTemplate.mutateAsync({ templateName: name, description: description || null, ...files, requiredSkillIds });
         onClose();
         return;
       }
       // Saving publishes a new immutable version; the name is inherited.
-      const updated = await updateTemplate.mutateAsync({ slug: slug!, description: description || null, ...files });
+      const updated = await updateTemplate.mutateAsync({ slug: slug!, description: description || null, ...files, requiredSkillIds });
       await refetch();
       setSelectedVersion(updated.version);
       setEditing(false);
@@ -222,10 +252,138 @@ export function TemplateDrawer({
                   </div>
                 </div>
               )}
+
+              {mode === "view" && !editing && (
+                <div className="flex flex-col gap-1.5">
+                  <label className="text-[13px] font-medium" style={{ color: "var(--ink-2)" }}>
+                    Required skills
+                  </label>
+                  {current && current.requiredSkills.length > 0 ? (
+                    <div className="flex flex-wrap gap-1.5">
+                      {current.requiredSkills.map((skill) => (
+                        <span
+                          key={skill.id}
+                          className="text-[12px] font-medium px-2.5 py-0.5 rounded-full"
+                          style={{ background: "var(--bg-soft)", color: "var(--ink-2)", border: "1px solid var(--line)" }}
+                        >
+                          {skill.name}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-[13px]" style={{ color: "var(--ink-4)" }}>None</div>
+                  )}
+                </div>
+              )}
+
               {mode === "view" && editing && (
                 <div className="text-[12.5px]" style={{ color: "var(--ink-3)" }}>
                   Editing from <span className="font-mono">v{current?.version}</span>. Saving publishes a new
                   version. <span className="font-mono">{"{{ … }}"}</span> placeholders are rendered when an agent starts.
+                </div>
+              )}
+
+              {editing && (
+                <div className="flex flex-col gap-2">
+                  <label className="text-[13px] font-medium" style={{ color: "var(--ink-2)" }}>
+                    Required skills
+                  </label>
+
+                  {selectedSkillDetails.length > 0 ? (
+                    <div className="flex flex-col gap-2 overflow-y-auto" style={{ maxHeight: "15rem" }}>
+                      {selectedSkillDetails.map((skill) => (
+                        <div
+                          key={skill.id}
+                          className="flex items-center gap-2 px-3.5 py-2.5 rounded-2xl flex-shrink-0"
+                          style={{ border: "1px solid var(--line)", background: "var(--bg-soft)" }}
+                        >
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-[0.844rem]" style={{ color: "var(--ink)" }}>
+                                {skill.name}
+                              </span>
+                              <SkillSourceBadge source={skill.source} />
+                            </div>
+                            {skill.requiredProviders.length > 0 && (
+                              <span className="text-[0.75rem]" style={{ color: "var(--ink-4)" }}>
+                                Requires:{" "}
+                                {skill.requiredProviders.map((p) => SKILL_PROVIDER_LABELS[p] ?? p).join(", ")}
+                              </span>
+                            )}
+                          </div>
+                          <button
+                            className="af-btn af-btn-sm af-btn-ghost"
+                            onClick={() => removeRequiredSkill(skill.id)}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div
+                      className="py-4 text-center rounded-2xl text-[0.8125rem]"
+                      style={{ border: "1px dashed var(--line-strong)", color: "var(--ink-4)" }}
+                    >
+                      No required skills.
+                    </div>
+                  )}
+
+                  <div
+                    className="flex items-center gap-2 px-3 py-2 rounded-xl mt-1"
+                    style={{ border: "1px solid var(--line)", background: "var(--bg-elev)" }}
+                  >
+                    <SearchIcon size={14} style={{ color: "var(--ink-4)", flexShrink: 0 }} />
+                    <input
+                      className="flex-1 text-[0.8125rem] outline-none bg-transparent"
+                      style={{ color: "var(--ink)" }}
+                      placeholder="Search skills to add…"
+                      value={skillSearch}
+                      onChange={(e) => setSkillSearch(e.target.value)}
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-2 overflow-y-auto" style={{ maxHeight: "14rem" }}>
+                    {skillsLoading && (
+                      <div className="text-[0.8125rem] py-2 text-center" style={{ color: "var(--ink-3)" }}>
+                        Loading…
+                      </div>
+                    )}
+                    {!skillsLoading && unselectedSkills.length === 0 ? (
+                      <div className="text-[0.8125rem] py-2 text-center" style={{ color: "var(--ink-3)" }}>
+                        {skillSearch ? "No skills match." : "No more skills to add."}
+                      </div>
+                    ) : (
+                      unselectedSkills.map((skill) => (
+                        <div
+                          key={skill.id}
+                          className="flex items-center gap-2 px-3.5 py-2.5 rounded-2xl flex-shrink-0"
+                          style={{ border: "1px solid var(--line)" }}
+                        >
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-[0.844rem]" style={{ color: "var(--ink)" }}>
+                                {skill.name}
+                              </span>
+                              <SkillSourceBadge source={skill.source} />
+                            </div>
+                            {skill.requiredProviders.length > 0 && (
+                              <span className="text-[0.75rem]" style={{ color: "var(--ink-4)" }}>
+                                Requires:{" "}
+                                {skill.requiredProviders.map((p) => SKILL_PROVIDER_LABELS[p] ?? p).join(", ")}
+                              </span>
+                            )}
+                          </div>
+                          <button
+                            className="af-btn af-btn-sm af-btn-ghost"
+                            onClick={() => addRequiredSkill({ id: skill.id, name: skill.name, source: skill.source, requiredProviders: skill.requiredProviders })}
+                          >
+                            Add
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
                 </div>
               )}
 
@@ -247,8 +405,8 @@ export function TemplateDrawer({
               </div>
 
               <textarea
-                className="af-input font-mono text-[0.781rem] leading-[1.65] resize-none flex-1"
-                rows={18}
+                className="af-input font-mono text-[0.781rem] leading-[1.65] resize-none"
+                style={{ minHeight: "40rem" }}
                 readOnly={!editing}
                 aria-label={`${templateFileLabel(file)} content`}
                 value={displayFiles[file]}

--- a/ui/src/features/agents/hooks/use-create-template.ts
+++ b/ui/src/features/agents/hooks/use-create-template.ts
@@ -18,6 +18,7 @@ export type CreateTemplateData = {
   bootMd?: string;
   bootstrapMd?: string;
   heartbeatMd?: string;
+  requiredSkillIds?: string[];
 };
 
 export function useCreateTemplate() {

--- a/ui/src/features/agents/hooks/use-update-template.ts
+++ b/ui/src/features/agents/hooks/use-update-template.ts
@@ -19,6 +19,7 @@ export type UpdateTemplateData = {
   bootMd?: string;
   bootstrapMd?: string;
   heartbeatMd?: string;
+  requiredSkillIds?: string[];
 };
 
 export function useUpdateTemplate() {

--- a/ui/src/features/agents/integrations.ts
+++ b/ui/src/features/agents/integrations.ts
@@ -71,6 +71,46 @@ export const INTEGRATION_PROVIDERS: IntegrationProvider[] = [
       { key: "apiToken", label: "API token", type: "secret", required: true },
     ],
   },
+  {
+    id: "gmail",
+    label: "Gmail",
+    scopeNote: "OAuth2 access token with Gmail API scopes (gmail.readonly, gmail.send or gmail.modify as needed)",
+    fields: [
+      { key: "accessToken", label: "Access token", type: "secret", required: true },
+      { key: "userId", label: "User ID", type: "text", required: true, placeholder: "me or user@example.com" },
+    ],
+  },
+  {
+    id: "google_calendar",
+    label: "Google Calendar",
+    scopeNote: "OAuth2 access token with calendar.readonly or calendar scope",
+    fields: [
+      { key: "accessToken", label: "Access token", type: "secret", required: true },
+      { key: "calendarId", label: "Calendar ID", type: "text", required: true, placeholder: "primary or calendar@group.calendar.google.com" },
+    ],
+  },
+  {
+    id: "zoho_mail",
+    label: "Zoho Mail",
+    scopeNote: "App password from Zoho account security settings (two-factor must be enabled)",
+    fields: [
+      { key: "username", label: "Username", type: "text", required: true, placeholder: "you@zoho.com" },
+      { key: "email", label: "Email", type: "text", required: true, placeholder: "you@zoho.com" },
+      { key: "fromAddress", label: "From address", type: "text", required: true, placeholder: "you@zoho.com" },
+      { key: "appPassword", label: "App password", type: "secret", required: true },
+    ],
+  },
+  {
+    id: "zoho_calendar",
+    label: "Zoho Calendar",
+    scopeNote: "App password from Zoho account security settings (two-factor must be enabled)",
+    fields: [
+      { key: "username", label: "Username", type: "text", required: true, placeholder: "you@zoho.com" },
+      { key: "email", label: "Email", type: "text", required: true, placeholder: "you@zoho.com" },
+      { key: "appPassword", label: "App password", type: "secret", required: true },
+      { key: "caldavUrl", label: "CalDAV URL", type: "text", required: true, placeholder: "https://calendar.zoho.com/caldav/..." },
+    ],
+  },
 ];
 
 export function getIntegrationProvider(id: string): IntegrationProvider | undefined {

--- a/ui/src/features/agents/schemas.ts
+++ b/ui/src/features/agents/schemas.ts
@@ -22,6 +22,7 @@ export const AgentAssignedSkillSchema = z.object({
   source: z.string(),
   requiredProviders: z.array(z.string()),
   toolsPointer: z.string().nullable(),
+  required: z.boolean().default(false),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -61,6 +62,7 @@ export const AgentTemplateReadSchema = z.object({
   bootMd: z.string(),
   bootstrapMd: z.string(),
   heartbeatMd: z.string(),
+  requiredSkills: z.array(AgentAssignedSkillSchema).default([]),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-import { MOCK_AGENT_ID, mockAgent, mockAssignedSkill, mockSecret, mockToolCall } from "../pages/data-support/agent-data-support.po";
-import { mockCustomSkill, mockPlatformSkill } from "../pages/data-support/skill-data-support.po";
+import { MOCK_AGENT_ID, mockAgent, mockAssignedSkill, mockSecret, mockToolCall, mockVersionsForSlug } from "../pages/data-support/agent-data-support.po";
+import { mockCustomSkill, mockPlatformSkill, MOCK_PLATFORM_SKILL_ID } from "../pages/data-support/skill-data-support.po";
 import { DataSupport } from "../pages/data-support/data-support.po";
 import { AgentDetailPage } from "../pages/agent-detail-page.po";
 
@@ -228,6 +228,77 @@ test.describe("Agent Detail Page — Template tab (re-pin)", () => {
     // No per-agent markdown is ever sent.
     expect(body.soul_md).toBeUndefined();
   });
+
+  test("shows Required skills section when re-pinning to template with required skills", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest({
+      body: mockVersionsForSlug("scrum-master").map((v) => ({
+        ...v,
+        required_skills: [{
+          id: MOCK_PLATFORM_SKILL_ID,
+          name: "github",
+          source: "aai_cli",
+          required_providers: ["github"],
+          tools_pointer: null,
+          required: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+      })),
+    });
+
+    await page.getByRole("button", { name: /Scrum Master/ }).click();
+
+    await expect(page.getByText("Required skills", { exact: true })).toBeVisible();
+    await expect(page.getByText(mockPlatformSkill.name, { exact: true })).toBeVisible();
+    await expect(page.getByText(/needs.*credential/)).toBeVisible();
+  });
+
+  test("Apply button is disabled when required skill credential form is incomplete", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest({
+      body: mockVersionsForSlug("scrum-master").map((v) => ({
+        ...v,
+        required_skills: [{
+          id: MOCK_PLATFORM_SKILL_ID,
+          name: "github",
+          source: "aai_cli",
+          required_providers: ["github"],
+          tools_pointer: null,
+          required: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+      })),
+    });
+
+    await page.getByRole("button", { name: /Scrum Master/ }).click();
+
+    await expect(page.getByRole("button", { name: "Apply template" })).toBeDisabled();
+  });
+
+  test("Apply button enables after filling required skill credentials", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest({
+      body: mockVersionsForSlug("scrum-master").map((v) => ({
+        ...v,
+        required_skills: [{
+          id: MOCK_PLATFORM_SKILL_ID,
+          name: "github",
+          source: "aai_cli",
+          required_providers: ["github"],
+          tools_pointer: null,
+          required: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+      })),
+    });
+
+    await page.getByRole("button", { name: /Scrum Master/ }).click();
+
+    await page.getByPlaceholder(/github_pat_/).fill("github_pat_test_token");
+    await page.getByPlaceholder(/https:\/\/github\.com\/owner\/repo\.git/).fill("https://github.com/owner/repo.git");
+
+    await expect(page.getByRole("button", { name: "Apply template" })).toBeEnabled();
+  });
 });
 
 test.describe("Agent Detail Page — Channels tab", () => {
@@ -402,6 +473,31 @@ test.describe("Agent Detail Page — Skills tab", () => {
     );
     await agentDetailPage.saveSkillsButton().click();
     await updatePromise;
+  });
+
+  test("required skill shows 'Required' badge and disabled Remove button", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetAgentRequest({
+      body: { ...mockAgent, status: "STOPPED", skills: [{ ...mockAssignedSkill, required: true }] },
+    });
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await agentDetailPage.configureButton().click();
+    await agentDetailPage.skillsTab().click();
+
+    await expect(page.getByText("Required", { exact: true })).toBeVisible();
+    await expect(agentDetailPage.removeSkillButton()).toBeDisabled();
+  });
+
+  test("hovering disabled Remove button for required skill shows tooltip", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetAgentRequest({
+      body: { ...mockAgent, status: "STOPPED", skills: [{ ...mockAssignedSkill, required: true }] },
+    });
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await agentDetailPage.configureButton().click();
+    await agentDetailPage.skillsTab().click();
+
+    await agentDetailPage.removeSkillButton().hover();
+
+    await expect(page.getByText("Required by template")).toBeVisible();
   });
 });
 

--- a/ui/tests/e2e/hire-dialog.spec.ts
+++ b/ui/tests/e2e/hire-dialog.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { mockAgent } from "../pages/data-support/agent-data-support.po";
+import { mockAgent, mockVersionsForSlug } from "../pages/data-support/agent-data-support.po";
 import { DataSupport } from "../pages/data-support/data-support.po";
 import { DashboardPage } from "../pages/dashboard-page.po";
-import { mockPlatformSkill, mockCustomSkill } from "../pages/data-support/skill-data-support.po";
+import { mockPlatformSkill, mockCustomSkill, MOCK_PLATFORM_SKILL_ID } from "../pages/data-support/skill-data-support.po";
 
 test.describe("Hire Dialog", () => {
   test.describe.configure({ mode: "serial" });
@@ -418,5 +418,97 @@ test.describe("Hire Dialog — Skills step", () => {
 
     await page.getByText(mockPlatformSkill.name, { exact: true }).click();
     await expect(page.getByText("Required credentials", { exact: true })).not.toBeVisible();
+  });
+
+  test("required skill card is shown as locked-selected with 'Required by template' label", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest({
+      body: mockVersionsForSlug("general-purpose").map((v) => ({
+        ...v,
+        required_skills: [{
+          id: MOCK_PLATFORM_SKILL_ID,
+          name: "github",
+          source: "aai_cli",
+          required_providers: ["github"],
+          tools_pointer: null,
+          required: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+      })),
+    });
+
+    await navigateToSkillsStep(page);
+
+    await expect(page.getByText(mockPlatformSkill.name, { exact: true })).toBeVisible();
+    await expect(page.getByText("Required by template")).toBeVisible();
+  });
+
+  test("clicking a required skill card does not deselect it", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest({
+      body: mockVersionsForSlug("general-purpose").map((v) => ({
+        ...v,
+        required_skills: [{
+          id: MOCK_PLATFORM_SKILL_ID,
+          name: "github",
+          source: "aai_cli",
+          required_providers: ["github"],
+          tools_pointer: null,
+          required: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+      })),
+    });
+
+    await navigateToSkillsStep(page);
+
+    await page.getByText(mockPlatformSkill.name, { exact: true }).click();
+
+    await expect(page.getByText("Required by template")).toBeVisible();
+  });
+
+  test("credential form appears for required skill provider without selecting the skill", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest({
+      body: mockVersionsForSlug("general-purpose").map((v) => ({
+        ...v,
+        required_skills: [{
+          id: MOCK_PLATFORM_SKILL_ID,
+          name: "github",
+          source: "aai_cli",
+          required_providers: ["github"],
+          tools_pointer: null,
+          required: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+      })),
+    });
+
+    await navigateToSkillsStep(page);
+
+    await expect(page.getByText("Required credentials", { exact: true })).toBeVisible();
+    await expect(page.getByPlaceholder(/github_pat_/)).toBeVisible();
+  });
+
+  test("hire button is disabled when required skill credentials are incomplete", async ({ page }) => {
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest({
+      body: mockVersionsForSlug("general-purpose").map((v) => ({
+        ...v,
+        required_skills: [{
+          id: MOCK_PLATFORM_SKILL_ID,
+          name: "github",
+          source: "aai_cli",
+          required_providers: ["github"],
+          tools_pointer: null,
+          required: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        }],
+      })),
+    });
+
+    await navigateToSkillsStep(page);
+
+    await expect(page.getByRole("button", { name: /hire aria/i })).toBeDisabled();
   });
 });

--- a/ui/tests/e2e/settings-templates.spec.ts
+++ b/ui/tests/e2e/settings-templates.spec.ts
@@ -2,9 +2,12 @@ import { expect, test } from "@playwright/test";
 
 import {
   mockAgentTemplate,
+  mockAssignedSkill,
   mockTemplates,
+  mockVersionsForSlug,
 } from "../pages/data-support/agent-data-support.po";
 import { DataSupport } from "../pages/data-support/data-support.po";
+import { MOCK_PLATFORM_SKILL_ID } from "../pages/data-support/skill-data-support.po";
 
 test.describe("Settings · Templates", () => {
   test.describe.configure({ mode: "serial" });
@@ -19,6 +22,7 @@ test.describe("Settings · Templates", () => {
     await dataSupport.users.interceptGetUserContextRequest();
     await dataSupport.agents.interceptGetTemplatesRequest();
     await dataSupport.agents.interceptGetTemplateVersionsRequest();
+    await dataSupport.skills.interceptGetSkillsRequest();
 
     await page.goto("/dashboard/settings");
     await page.getByRole("button", { name: "Templates", exact: true }).click();
@@ -122,5 +126,43 @@ test.describe("Settings · Templates", () => {
     await page.getByRole("button", { name: "Create template" }).click();
 
     await expect(page.getByText(/already exists/)).toBeVisible();
+  });
+
+  test("view mode shows Required skills None when template has no required skills", async ({ page }) => {
+    await page.getByText("My Custom", { exact: true }).click();
+
+    await expect(page.getByText("Required skills")).toBeVisible();
+    await expect(page.getByText("None", { exact: true })).toBeVisible();
+  });
+
+  test("view mode shows required skill pill when template has required skills", async ({ page }) => {
+    const versions = mockVersionsForSlug("my-custom").map((v) => ({
+      ...v,
+      required_skills: [mockAssignedSkill],
+    }));
+    await dataSupport.agents.interceptGetTemplateVersionsRequest({ body: versions });
+
+    await page.getByText("My Custom", { exact: true }).click();
+
+    await expect(page.getByText("Required skills")).toBeVisible();
+    await expect(page.getByText(mockAssignedSkill.name, { exact: true })).toBeVisible();
+  });
+
+  test("edit mode adding a skill sends required_skill_ids in PATCH body", async ({ page }) => {
+    await dataSupport.agents.interceptUpdateTemplateRequest({ slug: "my-custom" });
+
+    await page.getByText("My Custom", { exact: true }).click();
+    await page.getByRole("button", { name: "Edit template" }).click();
+
+    // Add the first available skill (github).
+    await page.getByRole("button", { name: "Add" }).first().click();
+
+    const patchPromise = page.waitForRequest(
+      (req) => req.url().includes("/api/v1/templates/my-custom") && req.method() === "PATCH",
+    );
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    const patchRequest = await patchPromise;
+    const body = patchRequest.postDataJSON() as Record<string, unknown>;
+    expect(body.required_skill_ids).toEqual([MOCK_PLATFORM_SKILL_ID]);
   });
 });

--- a/ui/tests/pages/data-support/agent-data-support.po.ts
+++ b/ui/tests/pages/data-support/agent-data-support.po.ts
@@ -39,6 +39,7 @@ export const mockAssignedSkill = {
   source: "aai_cli",
   required_providers: ["github"],
   tools_pointer: null,
+  required: false,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 };
@@ -71,6 +72,7 @@ export const mockAgentTemplate = {
   boot_md: "",
   bootstrap_md: "",
   heartbeat_md: "",
+  required_skills: [],
   created_at: "2026-03-14T00:00:00Z",
   updated_at: "2026-05-14T09:14:00Z",
 };
@@ -518,9 +520,11 @@ export class AgentDataSupport {
   async interceptGetTemplateVersionsRequest({
     status = 200,
     detail = "Unable to load versions",
+    body,
   }: {
     status?: number;
     detail?: string;
+    body?: unknown;
   } = {}) {
     await this.page.route("**/api/v1/templates/*/versions", async (route) => {
       if (route.request().method() !== "GET") {
@@ -535,7 +539,7 @@ export class AgentDataSupport {
         status,
         contentType: "application/json",
         body: JSON.stringify(
-          status >= 400 ? { detail } : mockVersionsForSlug(slug),
+          status >= 400 ? { detail } : (body ?? mockVersionsForSlug(slug)),
         ),
       });
     });


### PR DESCRIPTION
Templates can now declare required skills.

**Backend**

  - Added agent_template_skill join table (migration included) linking template versions to required skills with ON DELETE CASCADE on the template side and RESTRICT on the skill side
  - TemplateRead now includes required_skills; TemplateCreate/TemplateUpdate accept required_skill_ids
  - Scrum Master predefined template seeds Jira + Confluence as required skills at startup. I decided not to add any required skills to the PR reviewer template. The reason for that is that this template requires either Bitbucket or Github. I didn't want to enforce to make both or only one skill necessary. I think it makes sense that the user will add the skill to the template based on their needs. 
  - AgentAssignedSkillRead gained a required: bool field, populated based on the agent's current template version
  - create_agent rejects with 400 if required skills are missing from skill_ids
  - update_agent rejects with 409 if required skills are in removed_skill_ids, and with 400 if re-pinning to a template whose required skills aren't covered
  - delete_skill rejects with 409 if the skill is required by any template
  - new backend integration tests were added covering all the above cases

**Update**: I have made one skill required for PR reviewer. I have made GitHub as a required one. This will be as a default required skill for PR reviewer. The logic is that if the org uses bitbucket instead of GitHub, they can just modify the template and use new version of the template which makes sense in our application.

**Frontend**
1. Template drawer
  - View mode shows a "Required skills" section with pill badges, or "None"
  - Edit mode shows all available skills as toggle pills; selection is saved in required_skill_ids on PATCH. The UI of skills part was made consistent with the UI for skills managing in the agent config.

2. Hire wizard - Skills step
  - Required skills appear first in the grid, locked-selected with a "Required by template" label
  - Hire button is disabled until all required credential fields are filled

 3. Agent skills tab
  - Required skills show a "Required" badge
  - Remove button is disabled with a "Required by template" tooltip

 4. Config drawer — Template re-pin
  - When re-pinning to a template with required skills, a "Required skills" section appears showing each skill with a "· needs X credential" hint and credential forms for any providers not already configured
  - Apply button is disabled until all required credential forms are complete
  - Required skill IDs and credentials are included in the PATCH payload

 5. Tests were added