### PR TITLE
hermes agent home channel fix

### DIFF
--- a/api/domains/agents/builders/hermes.py
+++ b/api/domains/agents/builders/hermes.py
@@ -9,6 +9,7 @@ from .common import _labels, _resource_name
 _SCRIPTS = Path(__file__).parent.parent / "scripts" / "hermes"
 _DENY_DMS = _SCRIPTS / "plugins" / "slack-deny-dms"
 _CHANNEL_ALLOWLIST = _SCRIPTS / "plugins" / "slack-channel-allowlist"
+_NO_HOME_CHANNEL = "C0000000000"
 
 HERMES_BOOTLOADER_FOOTER: str = (_SCRIPTS / "bootloader-footer.md").read_text()
 HERMES_HEALTHZ_PY: str = (_SCRIPTS / "healthz-server.py").read_text()
@@ -179,7 +180,7 @@ def build_secret_hermes_slack(
             "API_SERVER_MODEL_NAME": agent_name,
             "GATEWAY_ALLOW_ALL_USERS": "true",
             "SLACK_ALLOW_ALL_USERS": "true",
-            "SLACK_HOME_CHANNEL": channel_ids[0] if channel_ids else "",
+            "SLACK_HOME_CHANNEL": channel_ids[0] if channel_ids else _NO_HOME_CHANNEL,
             "SLACK_CHANNEL_IDS": ",".join(channel_ids),
             "SLACK_DM_ALLOWED_USERS": ",".join(allowed_dm_users),
         },

--- a/api/tests/unit/test_hermes_builders.py
+++ b/api/tests/unit/test_hermes_builders.py
@@ -152,6 +152,7 @@ def test_build_secret_hermes_slack_contains_required_keys():
     assert_that(data["SLACK_BOT_TOKEN"], equal_to("xoxb-bot"))
     assert_that(data["SLACK_APP_TOKEN"], equal_to("xapp-app"))
     assert_that(data["API_SERVER_KEY"], equal_to("secret-key-123"))
+    assert_that(data["SLACK_HOME_CHANNEL"], equal_to("C001"))
     assert_that(data["SLACK_CHANNEL_IDS"], equal_to("C001,C002"))
     assert_that(data["SLACK_DM_ALLOWED_USERS"], equal_to("U001,U002"))
     assert_that(data["SLACK_ALLOW_ALL_USERS"], equal_to("true"))
@@ -174,6 +175,7 @@ def test_build_secret_hermes_slack_empty_lists_give_empty_strings():
         channel_ids=[],
         dm_user_ids=[],
     )
+    assert_that(secret.string_data["SLACK_HOME_CHANNEL"], equal_to("C0000000000"))
     assert_that(secret.string_data["SLACK_CHANNEL_IDS"], equal_to(""))
     assert_that(secret.string_data["SLACK_DM_ALLOWED_USERS"], equal_to(""))
 

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
 version: 0.5.0
-appVersion: "0.22.0"
+appVersion: "0.23.0"

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
 version: 0.5.0
-appVersion: "0.23.0"
+appVersion: "0.24.0"

--- a/helm/agentfarm-ui/Chart.yaml
+++ b/helm/agentfarm-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-ui
 description: Next.js frontend for agent-farm
 version: 0.5.0
-appVersion: "0.20.2"
+appVersion: "0.21.0"

--- a/ui/src/features/agents/components/slack-config-panel.tsx
+++ b/ui/src/features/agents/components/slack-config-panel.tsx
@@ -35,6 +35,8 @@ export function SlackConfigPanel({ agent, onSaved }: SlackConfigPanelProps) {
   const [channelFocused, setChannelFocused] = useState(false);
   const [userFocused, setUserFocused] = useState(false);
   const [saved, setSaved] = useState(false);
+  const shouldShowHermesHomeChannelMessage =
+    agent.agentType === "hermes" && channelIds.length === 0;
 
   const selectedChannels = channelIds
     .map((id) => channels.find((c) => c.id === id))
@@ -94,6 +96,12 @@ export function SlackConfigPanel({ agent, onSaved }: SlackConfigPanelProps) {
             <option value="allowlist">Allowlist — only allowed channels</option>
           </select>
         </div>
+
+        {shouldShowHermesHomeChannelMessage && (
+          <p className="text-[0.781rem]" style={{ color: "var(--err)" }}>
+            Set up a home channel for Hermes if you want scheduled or proactive Slack delivery.
+          </p>
+        )}
 
         {groupPolicy === "allowlist" && (
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
If no home channel is set during configuration an agent is fed a dummy channel so it doesn't show a generic Hermes message on first interaction. A UI message is also displayed if a user does not set a home channel