### PR TITLE
Af 161 allow automatic approval of commands

### DIFF
--- a/api/domains/agents/builders/hermes.py
+++ b/api/domains/agents/builders/hermes.py
@@ -24,11 +24,15 @@ SLACK_CHANNEL_ALLOWLIST_PLUGIN_INIT: str = (
 ).read_text()
 
 
+_HERMES_APPROVAL_MODE = {"manual": "manual", "auto": "smart", "off": "off"}
+
+
 def build_hermes_config(
     model: str,
     litellm_base_url: str,
     dm_policy: str = "off",
     group_policy: str = "allowlist",
+    approval_mode: str = "auto",
 ) -> dict:
     _, sep, model_name = model.partition("/")
     if not sep:
@@ -88,6 +92,9 @@ def build_hermes_config(
         },
         "plugins": {
             "enabled": enabled_plugins,
+        },
+        "approvals": {
+            "mode": _HERMES_APPROVAL_MODE.get(approval_mode, "smart"),
         },
     }
 

--- a/api/domains/agents/builders/openclaw.py
+++ b/api/domains/agents/builders/openclaw.py
@@ -13,6 +13,9 @@ HEALTHZ_SERVER_JS: str = (_SCRIPTS / "healthz-server.js").read_text()
 START_SH: str = (_SCRIPTS / "start.sh").read_text()
 
 
+_OPENCLAW_EXEC_MODE = {"manual": "ask", "auto": "auto", "off": "full"}
+
+
 def build_openclaw_config_overlay(
     model: str,
     litellm_base_url: str,
@@ -20,6 +23,7 @@ def build_openclaw_config_overlay(
     slack_dm_user_ids: list[str] | None = None,
     slack_group_policy: str = "open",
     slack_dm_policy: str = "open",
+    approval_mode: str = "auto",
 ) -> dict:
     provider, _, model_name = model.partition("/")
 
@@ -84,7 +88,10 @@ def build_openclaw_config_overlay(
         "bindings": [
             {"type": "route", "agentId": "main", "match": {"channel": "slack"}}
         ],
-        "tools": {"profile": "full"},
+        "tools": {
+            "profile": "full",
+            "exec": {"mode": _OPENCLAW_EXEC_MODE.get(approval_mode, "auto")},
+        },
         "memory": {"backend": "builtin"},
         "plugins": {
             "allow": ["memory-core", "active-memory"],
@@ -113,6 +120,7 @@ def build_openclaw_config_overlay(
 def build_openclaw_config_overlay_teams(
     model: str,
     litellm_base_url: str,
+    approval_mode: str = "auto",
 ) -> dict:
     provider, _, model_name = model.partition("/")
 
@@ -145,7 +153,10 @@ def build_openclaw_config_overlay_teams(
         "bindings": [
             {"type": "route", "agentId": "main", "match": {"channel": "msteams"}}
         ],
-        "tools": {"profile": "full"},
+        "tools": {
+            "profile": "full",
+            "exec": {"mode": _OPENCLAW_EXEC_MODE.get(approval_mode, "auto")},
+        },
         "memory": {"backend": "builtin"},
         "plugins": {
             "allow": ["memory-core", "active-memory"],

--- a/api/domains/agents/models.py
+++ b/api/domains/agents/models.py
@@ -19,6 +19,12 @@ class AgentStatus(str, enum.Enum):
     ERROR = "ERROR"
 
 
+class CommandApprovalMode(str, enum.Enum):
+    MANUAL = "manual"
+    AUTO = "auto"
+    OFF = "off"
+
+
 class AgentPlatform(str, enum.Enum):
     SLACK = "slack"
     TEAMS = "teams"
@@ -202,6 +208,10 @@ class Agent(BaseModel, table=True):
         nullable=True,
         sa_type=sa.Text,
     )
+    approval_mode: CommandApprovalMode = SqlField(
+        default=CommandApprovalMode.AUTO,
+        sa_column=Column(sa.String(10), nullable=False, server_default="auto"),
+    )
 
 
 class AgentSlackConfig(BaseModel, table=True):
@@ -325,6 +335,7 @@ class AgentCreate(PydanticBaseModel):
     secrets: list[AgentSecretCreate] = Field(default_factory=list)
     # Custom org skills to assign on creation (optional)
     skill_ids: list[UUID] = Field(default_factory=list)
+    approval_mode: CommandApprovalMode = CommandApprovalMode.AUTO
 
     @model_validator(mode="after")
     def validate_platform_credentials(self) -> "AgentCreate":
@@ -380,6 +391,7 @@ class AgentUpdate(PydanticBaseModel):
     # Providers not mentioned in either list are left untouched.
     secrets: list[AgentSecretCreate] | None = None
     removed_secret_providers: list[SecretProvider] | None = None
+    approval_mode: CommandApprovalMode | None = None
 
     @model_validator(mode="after")
     def validate_skill_operations(self) -> "AgentUpdate":
@@ -462,6 +474,7 @@ class AgentRead(PydanticBaseModel):
     teams_config: AgentTeamsConfigRead | None = None
     secrets: list[AgentSecretRead] = Field(default_factory=list)
     skills: list[AgentAssignedSkillRead] = Field(default_factory=list)
+    approval_mode: CommandApprovalMode
     webhook_url: str | None = None
     created_at: datetime
     updated_at: datetime

--- a/api/domains/agents/service.py
+++ b/api/domains/agents/service.py
@@ -356,6 +356,7 @@ class AgentService:
             template_slug=agent.template_slug,
             template_version=agent.template_version,
             model=agent.model,
+            approval_mode=agent.approval_mode,
             slack_config=slack_config_read,
             teams_config=teams_config_read,
             secrets=secrets_read,
@@ -449,6 +450,7 @@ class AgentService:
             agent_type=data.agent_type,
             template_slug=template.template_slug,
             template_version=template.version,
+            approval_mode=data.approval_mode,
         )
 
         if self.config.litellm_base_url and self.config.litellm_secret_name:
@@ -671,6 +673,9 @@ class AgentService:
             self._ensure_model_allowed(updated["model"])
             agent.model = updated["model"]
 
+        if "approval_mode" in updated:
+            agent.approval_mode = updated["approval_mode"]
+
         # Validate skill changes against the effective template's required skills
         if effective_template is None:
             effective_template = (
@@ -878,6 +883,7 @@ class AgentService:
                     self.config.agent_litellm_base_url,
                     dm_policy=str(slack_config.dm_policy),
                     group_policy=str(slack_config.group_policy),
+                    approval_mode=str(agent.approval_mode),
                 )
                 secret = build_secret_hermes_slack(
                     agent_id=agent.id,
@@ -908,6 +914,7 @@ class AgentService:
                     slack_dm_user_ids=slack_config.dm_user_ids,
                     slack_group_policy=str(slack_config.group_policy),
                     slack_dm_policy=str(slack_config.dm_policy),
+                    approval_mode=str(agent.approval_mode),
                 )
                 secret = build_secret_slack(
                     agent_id=agent.id,
@@ -942,6 +949,7 @@ class AgentService:
             overlay = build_openclaw_config_overlay_teams(
                 effective_model,
                 self.config.agent_litellm_base_url,
+                approval_mode=str(agent.approval_mode),
             )
             secret = build_secret_teams(
                 agent_id=agent.id,

--- a/api/migrations/versions/b1c2d3e4f5a6_add_approval_mode_to_agent.py
+++ b/api/migrations/versions/b1c2d3e4f5a6_add_approval_mode_to_agent.py
@@ -1,0 +1,27 @@
+"""add approval_mode to agent
+
+Revision ID: b1c2d3e4f5a6
+Revises: 032ff9a474bb
+Create Date: 2026-07-03
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "c89367ccd358"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("agent", sa.Column("approval_mode", sa.String(10), nullable=True))
+    op.execute("UPDATE agent SET approval_mode = 'auto' WHERE approval_mode IS NULL")
+    op.alter_column("agent", "approval_mode", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("agent", "approval_mode")

--- a/api/tests/integration/test_agents.py
+++ b/api/tests/integration/test_agents.py
@@ -210,6 +210,34 @@ def test_create_agent_does_not_create_template_rows():
             assert_that(latest.version, equal_to(1))
 
 
+def test_create_agent_default_approval_mode_is_auto():
+    with given(_GIVEN) as context:
+        client: TestClient = context.client
+
+        with when("I create an agent without specifying approval_mode"):
+            response = client.post(_BASE, json=_VALID_CREATE, headers=_auth(context))
+
+        with then("the response has approval_mode set to auto"):
+            assert_that(response.status_code, equal_to(status.HTTP_201_CREATED))
+            assert_that(response.json()["approval_mode"], equal_to("auto"))
+
+
+def test_create_agent_with_approval_mode_off():
+    with given(_GIVEN) as context:
+        client: TestClient = context.client
+
+        with when("I create an agent with approval_mode off"):
+            response = client.post(
+                _BASE,
+                json={**_VALID_CREATE, "approval_mode": "off"},
+                headers=_auth(context),
+            )
+
+        with then("the response has approval_mode set to off"):
+            assert_that(response.status_code, equal_to(status.HTTP_201_CREATED))
+            assert_that(response.json()["approval_mode"], equal_to("off"))
+
+
 def test_list_agents_returns_active_only():
     with given(
         [
@@ -392,6 +420,23 @@ def test_patch_agent_no_auth_returns_401():
 
         with then("it returns 401"):
             assert_that(response.status_code, equal_to(status.HTTP_401_UNAUTHORIZED))
+
+
+def test_patch_agent_approval_mode():
+    with given([*_GIVEN, there_is_an_agent()]) as context:
+        client: TestClient = context.client
+        agent_id = str(context.agent.id)
+
+        with when("I update the agent's approval_mode to manual"):
+            response = client.patch(
+                f"{_BASE}/{agent_id}",
+                json={"approval_mode": "manual"},
+                headers=_auth(context),
+            )
+
+        with then("the response reflects the new approval_mode"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            assert_that(response.json()["approval_mode"], equal_to("manual"))
 
 
 _JIRA_CONTENT = {

--- a/api/tests/unit/test_hermes_builders.py
+++ b/api/tests/unit/test_hermes_builders.py
@@ -366,3 +366,29 @@ def test_start_sh_includes_aai_cli_setup_hook():
 def test_start_sh_includes_skills_json_reconstruction():
     assert_that(HERMES_START_SH, contains_string("skills.json"))
     assert_that(HERMES_START_SH, contains_string("/workspace/skills"))
+
+
+def test_build_hermes_config_approval_mode_auto_maps_to_smart():
+    cfg = build_hermes_config(
+        "litellm/qwen3", "http://litellm:4000", approval_mode="auto"
+    )
+    assert_that(cfg["approvals"]["mode"], equal_to("smart"))
+
+
+def test_build_hermes_config_approval_mode_off():
+    cfg = build_hermes_config(
+        "litellm/qwen3", "http://litellm:4000", approval_mode="off"
+    )
+    assert_that(cfg["approvals"]["mode"], equal_to("off"))
+
+
+def test_build_hermes_config_approval_mode_manual():
+    cfg = build_hermes_config(
+        "litellm/qwen3", "http://litellm:4000", approval_mode="manual"
+    )
+    assert_that(cfg["approvals"]["mode"], equal_to("manual"))
+
+
+def test_build_hermes_config_default_approval_mode_is_smart():
+    cfg = build_hermes_config("litellm/qwen3", "http://litellm:4000")
+    assert_that(cfg["approvals"]["mode"], equal_to("smart"))

--- a/api/tests/unit/test_openclaw_builders.py
+++ b/api/tests/unit/test_openclaw_builders.py
@@ -1,0 +1,39 @@
+from hamcrest import assert_that, equal_to
+
+from api.domains.agents.builders.openclaw import (
+    build_openclaw_config_overlay,
+    build_openclaw_config_overlay_teams,
+)
+
+
+def test_build_openclaw_config_overlay_default_approval_mode_is_auto():
+    overlay = build_openclaw_config_overlay("litellm/gpt-4o", "http://litellm:4000")
+    assert_that(overlay["tools"]["exec"]["mode"], equal_to("auto"))
+
+
+def test_build_openclaw_config_overlay_approval_mode_manual():
+    overlay = build_openclaw_config_overlay(
+        "litellm/gpt-4o", "http://litellm:4000", approval_mode="manual"
+    )
+    assert_that(overlay["tools"]["exec"]["mode"], equal_to("ask"))
+
+
+def test_build_openclaw_config_overlay_approval_mode_off():
+    overlay = build_openclaw_config_overlay(
+        "litellm/gpt-4o", "http://litellm:4000", approval_mode="off"
+    )
+    assert_that(overlay["tools"]["exec"]["mode"], equal_to("full"))
+
+
+def test_build_openclaw_config_overlay_teams_default_approval_mode_is_auto():
+    overlay = build_openclaw_config_overlay_teams(
+        "litellm/gpt-4o", "http://litellm:4000"
+    )
+    assert_that(overlay["tools"]["exec"]["mode"], equal_to("auto"))
+
+
+def test_build_openclaw_config_overlay_teams_approval_mode_off():
+    overlay = build_openclaw_config_overlay_teams(
+        "litellm/gpt-4o", "http://litellm:4000", approval_mode="off"
+    )
+    assert_that(overlay["tools"]["exec"]["mode"], equal_to("full"))

--- a/ui/src/features/agents/components/config-drawer.tsx
+++ b/ui/src/features/agents/components/config-drawer.tsx
@@ -64,6 +64,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
   const [retireConfirm, setRetireConfirm] = useState(false);
   const [name, setName] = useState(agent.name);
   const [model, setModel] = useState(agent.model);
+  const [approvalMode, setApprovalMode] = useState(agent.approvalMode ?? "auto");
   const [saved, setSaved] = useState(false);
   // Template re-pin browsing state.
   const [templateSearch, setTemplateSearch] = useState("");
@@ -184,7 +185,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
 
   async function handleSave() {
     try {
-      await updateAgent.mutateAsync({ agentId: agent.id, name, model });
+      await updateAgent.mutateAsync({ agentId: agent.id, name, model, approvalMode });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch {
@@ -378,6 +379,19 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
                     disabled={isRunning}
                   />
                 </div>
+                <div className="flex flex-col gap-1.5">
+                  <label className="font-medium text-[0.844rem]" style={{ color: "var(--ink)" }}>Command approval</label>
+                  <select
+                    className="af-input"
+                    value={approvalMode}
+                    onChange={(e) => setApprovalMode(e.target.value as "manual" | "auto" | "off")}
+                    disabled={isRunning}
+                  >
+                    <option value="auto">Auto — approve low-risk commands automatically</option>
+                    <option value="manual">Manual — always ask before running commands</option>
+                    <option value="off">Off — skip all approval prompts</option>
+                  </select>
+                </div>
                 <div className="flex gap-2 items-center">
                   <button
                     className="af-btn af-btn-sm"
@@ -385,7 +399,7 @@ export function ConfigDrawer({ agent, activeTab, onTabChange, onClose }: ConfigD
                     title={isRunning ? "Stop the agent before saving changes" : undefined}
                     onClick={() => { void handleSave(); }}
                   >
-                    {updateAgent.isPending ? "Saving…" : saved ? "Saved!" : "Save name & model"}
+                    {updateAgent.isPending ? "Saving…" : saved ? "Saved!" : "Save"}
                   </button>
                 </div>
               </div>

--- a/ui/src/features/agents/components/hire-dialog-steps.tsx
+++ b/ui/src/features/agents/components/hire-dialog-steps.tsx
@@ -1072,6 +1072,8 @@ export function DetailsStep({
   onSlackGroupPolicyChange,
   slackDmPolicy,
   onSlackDmPolicyChange,
+  approvalMode,
+  onApprovalModeChange,
   onChangeTemplate,
 }: {
   template: AgentTemplateRead;
@@ -1084,6 +1086,8 @@ export function DetailsStep({
   onSlackGroupPolicyChange: (v: string) => void;
   slackDmPolicy: string;
   onSlackDmPolicyChange: (v: string) => void;
+  approvalMode: string;
+  onApprovalModeChange: (v: string) => void;
   onChangeTemplate: () => void;
 }) {
   const [previewFile, setPreviewFile] = useState<TemplateFileKey>("soulMd");
@@ -1118,6 +1122,18 @@ export function DetailsStep({
 
       <FormField label="Model">
         <ModelSelect value={model} onChange={onModelChange} aria-label="Model" />
+      </FormField>
+
+      <FormField label="Command approval">
+        <select
+          className="af-input"
+          value={approvalMode}
+          onChange={(e) => onApprovalModeChange(e.target.value)}
+        >
+          <option value="auto">Auto — approve low-risk commands automatically</option>
+          <option value="manual">Manual — always ask before running commands</option>
+          <option value="off">Off — skip all approval prompts</option>
+        </select>
       </FormField>
 
       {platform === "slack" && (

--- a/ui/src/features/agents/components/hire-dialog.tsx
+++ b/ui/src/features/agents/components/hire-dialog.tsx
@@ -123,6 +123,7 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
   const [agentType, setAgentType] = useState<"openclaw" | "hermes">("hermes");
   const [slackGroupPolicy, setSlackGroupPolicy] = useState<"open" | "allowlist">("allowlist");
   const [slackDmPolicy, setSlackDmPolicy] = useState<"off" | "open" | "allowlist">("off");
+  const [approvalMode, setApprovalMode] = useState<"manual" | "auto" | "off">("auto");
   const [teamsAppId, setTeamsAppId] = useState("");
   const [teamsAppPassword, setTeamsAppPassword] = useState("");
   const [showTeamsAppPassword, setShowTeamsAppPassword] = useState(false);
@@ -272,6 +273,7 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
           provider: c.provider,
           content: c.provider === "github" ? expandGithubContent(c.content) : c.content,
         })),
+        approvalMode,
         ...(platform === "slack"
           ? { slackBotToken, slackAppToken, slackGroupPolicy, slackDmPolicy }
           : { teamsAppId, teamsAppPassword, teamsTenantId }),
@@ -595,6 +597,7 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
             model={model} onModelChange={setModel}
             slackGroupPolicy={slackGroupPolicy} onSlackGroupPolicyChange={(v) => setSlackGroupPolicy(v as "open" | "allowlist")}
             slackDmPolicy={slackDmPolicy} onSlackDmPolicyChange={(v) => setSlackDmPolicy(v as "off" | "open" | "allowlist")}
+            approvalMode={approvalMode} onApprovalModeChange={(v) => setApprovalMode(v as "manual" | "auto" | "off")}
             onChangeTemplate={() => setStep("template")}
           />
         )}

--- a/ui/src/features/agents/hooks/use-create-agent.ts
+++ b/ui/src/features/agents/hooks/use-create-agent.ts
@@ -28,6 +28,7 @@ export type CreateAgentData = {
   skillIds?: string[];
   // Integration credentials (provider + provider-specific content; name is server-stamped)
   secrets?: Array<{ provider: string; content: Record<string, string> }>;
+  approvalMode?: "manual" | "auto" | "off";
 };
 
 export function useCreateAgent() {

--- a/ui/src/features/agents/hooks/use-update-agent.ts
+++ b/ui/src/features/agents/hooks/use-update-agent.ts
@@ -28,6 +28,7 @@ export type UpdateAgentData = {
   // Integration credentials: upsert (add/replace) + explicit removal.
   secrets?: Array<{ provider: string; content: Record<string, string> }>;
   removedSecretProviders?: string[];
+  approvalMode?: "manual" | "auto" | "off";
 };
 
 export function useUpdateAgent() {

--- a/ui/src/features/agents/schemas.ts
+++ b/ui/src/features/agents/schemas.ts
@@ -48,6 +48,7 @@ export const AgentSchema = z.object({
   templateSlug: z.string(),
   templateVersion: z.number().int(),
   model: z.string(),
+  approvalMode: z.enum(["manual", "auto", "off"]).default("auto"),
   slackConfig: AgentSlackConfigSchema.nullable().optional(),
   teamsConfig: AgentTeamsConfigSchema.nullable().optional(),
   secrets: z.array(AgentSecretReadSchema).optional(),
@@ -180,6 +181,7 @@ export const ModelOptionSchema = z.object({
   isDefault: z.boolean().optional(),
 });
 
+export type CommandApprovalMode = "manual" | "auto" | "off";
 export type Agent = z.infer<typeof AgentSchema>;
 export type AgentAssignedSkill = z.infer<typeof AgentAssignedSkillSchema>;
 export type AgentSlackConfig = z.infer<typeof AgentSlackConfigSchema>;

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -653,3 +653,48 @@ test.describe("Agent Detail Page — Keys tab", () => {
     await expect(agentDetailPage.saveIntegrationsButton()).toBeDisabled();
   });
 });
+
+test.describe("Agent Detail Page — Personality tab (approval mode)", () => {
+  test.describe.configure({ mode: "serial" });
+  let agentDetailPage: AgentDetailPage;
+  let dataSupportPage: DataSupport;
+
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page }) => {
+    agentDetailPage = new AgentDetailPage(page);
+    dataSupportPage = new DataSupport(page);
+
+    await dataSupportPage.auth.interceptRefreshRequest();
+    await dataSupportPage.users.interceptGetUserContextRequest();
+    await dataSupportPage.agents.interceptGetAgentRequest({
+      body: { ...mockAgent, status: "STOPPED" },
+    });
+    await dataSupportPage.agents.interceptGetAgentTemplateRequest();
+    await dataSupportPage.agents.interceptGetTemplatesRequest();
+    await dataSupportPage.agents.interceptGetTemplateVersionsRequest();
+    await dataSupportPage.agents.interceptUpdateAgentRequest();
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await agentDetailPage.configureButton().click();
+  });
+
+  test("shows command approval select defaulting to auto from agent data", async ({ page }) => {
+    await expect(page.getByText("Command approval")).toBeVisible();
+    await expect(page.locator('label:text-is("Command approval") + select')).toHaveValue("auto");
+  });
+
+  test("saving name & model sends approval_mode in the PATCH request", async ({ page }) => {
+    await page.locator('label:text-is("Command approval") + select').selectOption("off");
+
+    const patchPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes(`/api/v1/agents/${MOCK_AGENT_ID}`) &&
+        req.method() === "PATCH",
+    );
+    await page.getByRole("button", { name: /save name & model/i }).click();
+    const body = (await patchPromise).postDataJSON() as Record<string, unknown>;
+
+    expect(body.approval_mode).toBe("off");
+  });
+});

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -692,7 +692,7 @@ test.describe("Agent Detail Page — Personality tab (approval mode)", () => {
         req.url().includes(`/api/v1/agents/${MOCK_AGENT_ID}`) &&
         req.method() === "PATCH",
     );
-    await page.getByRole("button", { name: /save name & model/i }).click();
+    await page.getByRole("button", { name: /^save$/i }).click();
     const body = (await patchPromise).postDataJSON() as Record<string, unknown>;
 
     expect(body.approval_mode).toBe("off");

--- a/ui/tests/e2e/hire-dialog.spec.ts
+++ b/ui/tests/e2e/hire-dialog.spec.ts
@@ -215,6 +215,44 @@ test.describe("Hire Dialog", () => {
     await expect(preview).toHaveValue(/\{\{ agent_display_name \}\}/);
   });
 
+  test("details step shows command approval select defaulting to auto", async ({ page }) => {
+    await page.getByText("General Purpose", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click(); // template → slack-choice
+    await page.getByText("I already have a Slack app").click();
+    await page.getByRole("button", { name: /continue/i }).click(); // slack-choice → tokens
+    await page.getByPlaceholder(/xapp-/i).fill("xapp-1-test");
+    await page.getByPlaceholder(/xoxb-/i).fill("xoxb-test");
+    await page.getByRole("button", { name: /continue/i }).click(); // tokens → details
+
+    await expect(page.getByText("Command approval")).toBeVisible();
+    await expect(page.locator('label:text-is("Command approval") + select')).toHaveValue("auto");
+  });
+
+  test("hire posts approval_mode from details step selection", async ({ page }) => {
+    await dataSupportPage.agents.interceptCreateAgentRequest({ body: { ...mockAgent, status: "STOPPED" } });
+    await dataSupportPage.agents.interceptSlackChannelsRequest({ agentId: mockAgent.id });
+    await dataSupportPage.agents.interceptSlackUsersRequest({ agentId: mockAgent.id });
+
+    await page.getByText("General Purpose", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click(); // template → slack-choice
+    await page.getByText("I already have a Slack app").click();
+    await page.getByRole("button", { name: /continue/i }).click(); // slack-choice → tokens
+    await page.getByPlaceholder(/xapp-/i).fill("xapp-1-test");
+    await page.getByPlaceholder(/xoxb-/i).fill("xoxb-test");
+    await page.getByRole("button", { name: /continue/i }).click(); // tokens → details
+    await page.locator('label:text-is("Command approval") + select').selectOption("manual");
+    await page.getByRole("button", { name: /continue/i }).click(); // details → skills
+
+    const createPromise = page.waitForRequest(
+      (req) => req.url().includes("/api/v1/agents") && req.method() === "POST",
+    );
+    await page.getByRole("button", { name: "Hire Aria" }).click();
+    const createRequest = await createPromise;
+    const body = createRequest.postDataJSON() as Record<string, unknown>;
+
+    expect(body.approval_mode).toBe("manual");
+  });
+
   test("hire posts template_slug + selected version, not markdown", async ({ page }) => {
     await dataSupportPage.agents.interceptCreateAgentRequest({ body: { ...mockAgent, status: "STOPPED" } });
     await dataSupportPage.agents.interceptSlackChannelsRequest({ agentId: mockAgent.id });

--- a/ui/tests/pages/data-support/agent-data-support.po.ts
+++ b/ui/tests/pages/data-support/agent-data-support.po.ts
@@ -14,6 +14,7 @@ export const mockAgent = {
   template_slug: MOCK_TEMPLATE_SLUG,
   template_version: 1,
   model: "litellm/gpt-5-mini",
+  approval_mode: "auto",
   slack_config: {
     channel_ids: [],
     dm_user_ids: [],


### PR DESCRIPTION
**Research was done for both Hermes and Openclaw to explore approval mode for commands**. 

**For hermes, there are 3 different modes**:
- Manual (always prompt the user about any command)
- Smart (use an auxiliary LLM to auto-approve low-risk commands, prompt for high-risk)
- Off (skip all prompts (equivalent to --yolo))

**For OpenClaw, there are the following equivalents**:
- Ask (always prompt)
- Auto (auto-approve low-risk commands, prompt for high-risk)
- Full (skip all prompts)

Regarding Manual mode in hermes and Ask mode in OpenClaw: when the agent asks the user to execute command, the user can choose "Always Allow" option which will lead to agent always executing this command without asking. 

**Backend**                                                                                                                                                                                      
  - CommandApprovalMode enum + approval_mode column on the Agent model and all DTOs (AgentCreate, AgentUpdate, AgentRead)                                                                      
  - Alembic migration backfills existing rows to auto                                                                                                                           
  - build_hermes_config maps auto → smart, manual → manual, off → off and injects approvals.mode into hermes-config.yaml                                                                       
  - build_openclaw_config_overlay (Slack + Teams) maps auto → auto, manual → ask, off → full and injects tools.exec.mode into the config overlay                                               
  - create_agent, update_agent, start_agent all pass approval_mode through 
  - default value for approval mode will be Auto (or Smart for hermes)                                                                                                                    
                                                                                                                                                                                               
  **UI**                                                                                                                                                                                           
  - AgentSchema extended with approvalMode; CommandApprovalMode type exported                                                                                                                  
  - CreateAgentData / UpdateAgentData hooks extended with approvalMode?                                                                                                                        
  - Config drawer personality tab: approval mode select, saved alongside name & model                                                                                                          
  - Hire wizard details step: approval mode select with auto pre-selected                                                                                                                      
                                                                                                                                                                                               
  **Tests**                                                                                                                                                                                        
  - 3 integration tests (default auto, create with off, update mode)                                                                                                                           
  - 4 hermes builder unit tests, 6 openclaw builder unit tests                                                                                                                                 
  - 2 Playwright tests in hire-dialog (select visible + default; submitted in POST body)                                                                                                       
  - 2 Playwright tests in agent-detail-page (select visible + default; submitted in PATCH body)                                                                                                                                                                                                                                                                                                                                                      