### PR TITLE
Af 169 configurable verbose mode for hermes in slack

### DIFF
--- a/api/domains/agents/builders/hermes.py
+++ b/api/domains/agents/builders/hermes.py
@@ -29,6 +29,7 @@ def build_hermes_config(
     litellm_base_url: str,
     dm_policy: str = "off",
     group_policy: str = "allowlist",
+    verbose_mode: bool = True,
 ) -> dict:
     _, sep, model_name = model.partition("/")
     if not sep:
@@ -75,6 +76,8 @@ def build_hermes_config(
             "platforms": {
                 "slack": {
                     "tool_progress": "off",
+                    "interim_assistant_messages": verbose_mode,
+                    "busy_ack_detail": False,
                 },
             },
         },

--- a/api/domains/agents/models.py
+++ b/api/domains/agents/models.py
@@ -242,6 +242,10 @@ class AgentSlackConfig(BaseModel, table=True):
         default=SlackDmPolicy.OFF,
         sa_column=Column(sa.String(), nullable=False, server_default="off"),
     )
+    verbose_mode: bool = SqlField(
+        default=True,
+        sa_column=Column(sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
 
 
 class AgentTeamsConfig(BaseModel, table=True):
@@ -326,6 +330,7 @@ class AgentCreate(PydanticBaseModel):
     slack_dm_user_ids: list[str] = Field(default_factory=list)
     slack_group_policy: SlackGroupPolicy = SlackGroupPolicy.ALLOWLIST
     slack_dm_policy: SlackDmPolicy = SlackDmPolicy.OFF
+    slack_verbose_mode: bool = True
     # Teams credentials (required when platform=teams)
     teams_app_id: str | None = Field(default=None, min_length=1)
     teams_app_password: str | None = Field(default=None, min_length=1)
@@ -378,6 +383,7 @@ class AgentUpdate(PydanticBaseModel):
     slack_dm_user_ids: list[str] | None = None
     slack_group_policy: SlackGroupPolicy | None = None
     slack_dm_policy: SlackDmPolicy | None = None
+    slack_verbose_mode: bool | None = None
     # Teams
     teams_app_id: str | None = Field(default=None, min_length=1)
     teams_app_password: str | None = Field(default=None, min_length=1)
@@ -431,6 +437,7 @@ class AgentSlackConfigRead(PydanticBaseModel):
     dm_user_ids: list[str]
     group_policy: SlackGroupPolicy
     dm_policy: SlackDmPolicy
+    verbose_mode: bool
     bot_display_name: str | None = None  # fetched live from Slack, not persisted
 
 

--- a/api/domains/agents/service.py
+++ b/api/domains/agents/service.py
@@ -110,6 +110,7 @@ _SLACK_CONFIG_FIELDS = frozenset(
         "slack_dm_user_ids",
         "slack_group_policy",
         "slack_dm_policy",
+        "slack_verbose_mode",
     }
 )
 
@@ -493,6 +494,7 @@ class AgentService:
                 dm_user_ids=data.slack_dm_user_ids,
                 group_policy=data.slack_group_policy,
                 dm_policy=data.slack_dm_policy,
+                verbose_mode=data.slack_verbose_mode,
             )
             self.repository.save_slack_config(slack_config)
         elif data.platform == AgentPlatform.TEAMS:
@@ -747,6 +749,8 @@ class AgentService:
                     slack_config.group_policy = updated["slack_group_policy"]
                 if "slack_dm_policy" in updated:
                     slack_config.dm_policy = updated["slack_dm_policy"]
+                if "slack_verbose_mode" in updated:
+                    slack_config.verbose_mode = updated["slack_verbose_mode"]
                 self.repository.save_slack_config(slack_config)
                 if "slack_channel_ids" in updated:
                     self._join_public_channels(
@@ -878,6 +882,7 @@ class AgentService:
                     self.config.agent_litellm_base_url,
                     dm_policy=str(slack_config.dm_policy),
                     group_policy=str(slack_config.group_policy),
+                    verbose_mode=slack_config.verbose_mode,
                 )
                 secret = build_secret_hermes_slack(
                     agent_id=agent.id,

--- a/api/migrations/versions/d7e8f9a0b1c2_add_verbose_mode_to_agent_slack_config.py
+++ b/api/migrations/versions/d7e8f9a0b1c2_add_verbose_mode_to_agent_slack_config.py
@@ -1,0 +1,33 @@
+"""add verbose mode to agent slack config
+
+Revision ID: d7e8f9a0b1c2
+Revises: c89367ccd358
+Create Date: 2026-07-07 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d7e8f9a0b1c2"
+down_revision: Union[str, None] = "c89367ccd358"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_slack_config",
+        sa.Column(
+            "verbose_mode",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_slack_config", "verbose_mode")

--- a/api/tests/integration/test_agents.py
+++ b/api/tests/integration/test_agents.py
@@ -1461,6 +1461,7 @@ def test_create_agent_with_slack_settings():
             "slack_dm_user_ids": ["U001"],
             "slack_group_policy": "allowlist",
             "slack_dm_policy": "allowlist",
+            "slack_verbose_mode": False,
         }
 
         with when("I create an agent with Slack settings"):
@@ -1473,6 +1474,7 @@ def test_create_agent_with_slack_settings():
             assert_that(body["slack_config"]["dm_user_ids"], equal_to(["U001"]))
             assert_that(body["slack_config"]["group_policy"], equal_to("allowlist"))
             assert_that(body["slack_config"]["dm_policy"], equal_to("allowlist"))
+            assert_that(body["slack_config"]["verbose_mode"], equal_to(False))
 
 
 def test_create_agent_defaults_to_allowlist_groups_dms_off():
@@ -1489,6 +1491,7 @@ def test_create_agent_defaults_to_allowlist_groups_dms_off():
             assert_that(body["slack_config"]["dm_policy"], equal_to("off"))
             assert_that(body["slack_config"]["channel_ids"], equal_to([]))
             assert_that(body["slack_config"]["dm_user_ids"], equal_to([]))
+            assert_that(body["slack_config"]["verbose_mode"], equal_to(True))
 
 
 def test_patch_agent_updates_slack_settings():
@@ -1503,6 +1506,7 @@ def test_patch_agent_updates_slack_settings():
                     "slack_dm_user_ids": ["U888"],
                     "slack_group_policy": "open",
                     "slack_dm_policy": "allowlist",
+                    "slack_verbose_mode": False,
                 },
                 headers=_auth(context),
             )
@@ -1514,6 +1518,7 @@ def test_patch_agent_updates_slack_settings():
             assert_that(body["slack_config"]["dm_user_ids"], equal_to(["U888"]))
             assert_that(body["slack_config"]["group_policy"], equal_to("open"))
             assert_that(body["slack_config"]["dm_policy"], equal_to("allowlist"))
+            assert_that(body["slack_config"]["verbose_mode"], equal_to(False))
 
 
 def test_start_agent_overlay_uses_slack_settings():
@@ -2062,6 +2067,10 @@ def test_start_hermes_agent_configmap_has_hermes_config():
             cfg = _yaml.safe_load(config_map.data["hermes-config.yaml"])
             assert_that(cfg["model"]["base_url"], equal_to("http://litellm:4000"))
             assert_that(cfg["slack"]["unauthorized_dm_behavior"], equal_to("ignore"))
+            assert_that(
+                cfg["display"]["platforms"]["slack"]["interim_assistant_messages"],
+                equal_to(True),
+            )
             assert_that("slack-deny-dms" in cfg["plugins"]["enabled"], equal_to(True))
             assert_that(
                 "slack-channel-allowlist" in cfg["plugins"]["enabled"], equal_to(True)
@@ -2082,6 +2091,35 @@ def test_start_hermes_agent_configmap_has_hermes_config():
 
         with then("BOOTSTRAP.md is absent from the ConfigMap"):
             assert_that(config_map.data, is_not(has_key("BOOTSTRAP.md")))
+
+
+def test_start_hermes_agent_configmap_concise_mode():
+    import yaml as _yaml
+
+    with given(
+        [*_GIVEN_WITH_HERMES_IMAGE, there_is_an_agent(agent_type=AgentType.HERMES)]
+    ) as context:
+        client: TestClient = context.client
+        k8s: KubernetesClient = context.injector.get(KubernetesClient)
+
+        client.patch(
+            f"{_BASE}/{context.agent.id}",
+            json={"slack_verbose_mode": False},
+            headers=_auth(context),
+        )
+
+        with when("I start the Hermes agent in concise mode"):
+            response = client.post(
+                f"{_BASE}/{context.agent.id}/start", headers=_auth(context)
+            )
+
+        with then("hermes-config.yaml disables interim assistant messages"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            config_map = k8s.create_config_map.call_args.args[1]
+            cfg = _yaml.safe_load(config_map.data["hermes-config.yaml"])
+            slack_display = cfg["display"]["platforms"]["slack"]
+            assert_that(slack_display["interim_assistant_messages"], equal_to(False))
+            assert_that(slack_display["busy_ack_detail"], equal_to(False))
 
 
 def test_start_hermes_agent_secret_has_channel_and_dm_lists():

--- a/api/tests/unit/test_hermes_builders.py
+++ b/api/tests/unit/test_hermes_builders.py
@@ -232,6 +232,23 @@ def test_open_group_and_dm_policy_drops_both_gating_plugins():
     assert_that(cfg["plugins"]["enabled"], equal_to([]))
 
 
+def test_default_verbose_mode_enables_interim_assistant_messages():
+    cfg = build_hermes_config("litellm/qwen3", "http://x:4000")
+    slack_display = cfg["display"]["platforms"]["slack"]
+    assert_that(slack_display["interim_assistant_messages"], equal_to(True))
+    # Verbosity drives interim messages only; progress spam stays suppressed.
+    assert_that(slack_display["tool_progress"], equal_to("off"))
+    assert_that(slack_display["busy_ack_detail"], equal_to(False))
+
+
+def test_concise_mode_disables_interim_assistant_messages():
+    cfg = build_hermes_config("litellm/qwen3", "http://x:4000", verbose_mode=False)
+    slack_display = cfg["display"]["platforms"]["slack"]
+    assert_that(slack_display["interim_assistant_messages"], equal_to(False))
+    assert_that(slack_display["tool_progress"], equal_to("off"))
+    assert_that(slack_display["busy_ack_detail"], equal_to(False))
+
+
 def test_allowlist_policy_seeds_dm_allowed_users():
     secret = _secret_with(["U001", "U002"], "allowlist")
     assert_that(secret.string_data["SLACK_DM_ALLOWED_USERS"], equal_to("U001,U002"))

--- a/ui/src/features/agents/components/hire-dialog-steps.tsx
+++ b/ui/src/features/agents/components/hire-dialog-steps.tsx
@@ -1063,6 +1063,7 @@ export function TeamsCredentialsStep({
 export function DetailsStep({
   template,
   platform,
+  agentType,
   name,
   onNameChange,
   model,
@@ -1071,10 +1072,13 @@ export function DetailsStep({
   onSlackGroupPolicyChange,
   slackDmPolicy,
   onSlackDmPolicyChange,
+  slackVerboseMode,
+  onSlackVerboseModeChange,
   onChangeTemplate,
 }: {
   template: AgentTemplateRead;
   platform: "slack" | "teams";
+  agentType: "openclaw" | "hermes";
   name: string;
   onNameChange: (v: string) => void;
   model: string;
@@ -1083,6 +1087,8 @@ export function DetailsStep({
   onSlackGroupPolicyChange: (v: string) => void;
   slackDmPolicy: string;
   onSlackDmPolicyChange: (v: string) => void;
+  slackVerboseMode: boolean;
+  onSlackVerboseModeChange: (v: boolean) => void;
   onChangeTemplate: () => void;
 }) {
   const [previewFile, setPreviewFile] = useState<TemplateFileKey>("soulMd");
@@ -1143,6 +1149,22 @@ export function DetailsStep({
               <option value="open">Open — anyone can DM</option>
             </select>
           </FormField>
+
+          {agentType === "hermes" && (
+            <FormField
+              label="Verbosity"
+              hint="When verbose, the agent announces what it's about to do at each step."
+            >
+              <select
+                className="af-input"
+                value={slackVerboseMode ? "verbose" : "concise"}
+                onChange={(e) => onSlackVerboseModeChange(e.target.value === "verbose")}
+              >
+                <option value="verbose">Verbose — announces each step</option>
+                <option value="concise">Concise — final answers only</option>
+              </select>
+            </FormField>
+          )}
         </>
       )}
 

--- a/ui/src/features/agents/components/hire-dialog.tsx
+++ b/ui/src/features/agents/components/hire-dialog.tsx
@@ -123,6 +123,7 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
   const [agentType, setAgentType] = useState<"openclaw" | "hermes">("hermes");
   const [slackGroupPolicy, setSlackGroupPolicy] = useState<"open" | "allowlist">("allowlist");
   const [slackDmPolicy, setSlackDmPolicy] = useState<"off" | "open" | "allowlist">("off");
+  const [slackVerboseMode, setSlackVerboseMode] = useState(true);
   const [teamsAppId, setTeamsAppId] = useState("");
   const [teamsAppPassword, setTeamsAppPassword] = useState("");
   const [showTeamsAppPassword, setShowTeamsAppPassword] = useState(false);
@@ -273,7 +274,7 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
           content: c.provider === "github" ? expandGithubContent(c.content) : c.content,
         })),
         ...(platform === "slack"
-          ? { slackBotToken, slackAppToken, slackGroupPolicy, slackDmPolicy }
+          ? { slackBotToken, slackAppToken, slackGroupPolicy, slackDmPolicy, slackVerboseMode }
           : { teamsAppId, teamsAppPassword, teamsTenantId }),
       });
       setCreatedAgent(agent);
@@ -591,10 +592,12 @@ export function HireDialog({ onClose, onHired }: HireDialogProps) {
           <DetailsStep
             template={versionTemplate}
             platform={platform}
+            agentType={agentType}
             name={name} onNameChange={setName}
             model={model} onModelChange={setModel}
             slackGroupPolicy={slackGroupPolicy} onSlackGroupPolicyChange={(v) => setSlackGroupPolicy(v as "open" | "allowlist")}
             slackDmPolicy={slackDmPolicy} onSlackDmPolicyChange={(v) => setSlackDmPolicy(v as "off" | "open" | "allowlist")}
+            slackVerboseMode={slackVerboseMode} onSlackVerboseModeChange={setSlackVerboseMode}
             onChangeTemplate={() => setStep("template")}
           />
         )}

--- a/ui/src/features/agents/components/slack-config-panel.tsx
+++ b/ui/src/features/agents/components/slack-config-panel.tsx
@@ -30,6 +30,7 @@ export function SlackConfigPanel({ agent, onSaved }: SlackConfigPanelProps) {
   const [userIds, setUserIds] = useState<string[]>(agent.slackConfig?.dmUserIds ?? []);
   const [groupPolicy, setGroupPolicy] = useState<"open" | "allowlist">(agent.slackConfig?.groupPolicy ?? "open");
   const [dmPolicy, setDmPolicy] = useState<"off" | "open" | "allowlist">(agent.slackConfig?.dmPolicy ?? "off");
+  const [verboseMode, setVerboseMode] = useState<boolean>(agent.slackConfig?.verboseMode ?? true);
   const [channelSearch, setChannelSearch] = useState("");
   const [userSearch, setUserSearch] = useState("");
   const [channelFocused, setChannelFocused] = useState(false);
@@ -65,6 +66,7 @@ export function SlackConfigPanel({ agent, onSaved }: SlackConfigPanelProps) {
         slackDmUserIds: userIds,
         slackGroupPolicy: groupPolicy,
         slackDmPolicy: dmPolicy,
+        ...(agent.agentType === "hermes" ? { slackVerboseMode: verboseMode } : {}),
       });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
@@ -301,6 +303,34 @@ export function SlackConfigPanel({ agent, onSaved }: SlackConfigPanelProps) {
           </div>
         )}
       </section>
+
+      {agent.agentType === "hermes" && (
+        <section className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="slack-verbose-mode"
+              className="font-medium text-[0.844rem]"
+              style={{ color: "var(--ink)" }}
+            >
+              Verbosity
+            </label>
+            <select
+              id="slack-verbose-mode"
+              className="af-input"
+              value={verboseMode ? "verbose" : "concise"}
+              disabled={isRunning}
+              onChange={(e) => setVerboseMode(e.target.value === "verbose")}
+            >
+              <option value="verbose">Verbose — announces each step</option>
+              <option value="concise">Concise — final answers only</option>
+            </select>
+            <p className="text-[0.781rem]" style={{ color: "var(--ink-4)" }}>
+              When verbose, the agent announces what it&apos;s about to do at each step.
+              Takes effect the next time the agent starts.
+            </p>
+          </div>
+        </section>
+      )}
 
       <div className="flex items-center gap-2">
         <button

--- a/ui/src/features/agents/hooks/use-create-agent.ts
+++ b/ui/src/features/agents/hooks/use-create-agent.ts
@@ -16,6 +16,7 @@ export type CreateAgentData = {
   slackAppToken?: string;
   slackGroupPolicy?: "open" | "allowlist";
   slackDmPolicy?: "off" | "open" | "allowlist";
+  slackVerboseMode?: boolean;
   // Teams (required when platform=teams)
   teamsAppId?: string;
   teamsAppPassword?: string;

--- a/ui/src/features/agents/hooks/use-update-agent.ts
+++ b/ui/src/features/agents/hooks/use-update-agent.ts
@@ -20,6 +20,7 @@ export type UpdateAgentData = {
   slackDmUserIds?: string[];
   slackGroupPolicy?: "open" | "allowlist";
   slackDmPolicy?: "off" | "open" | "allowlist";
+  slackVerboseMode?: boolean;
   teamsAppId?: string;
   teamsAppPassword?: string;
   teamsTenantId?: string;

--- a/ui/src/features/agents/schemas.ts
+++ b/ui/src/features/agents/schemas.ts
@@ -5,6 +5,7 @@ export const AgentSlackConfigSchema = z.object({
   dmUserIds: z.array(z.string()),
   groupPolicy: z.enum(["open", "allowlist"]),
   dmPolicy: z.enum(["off", "open", "allowlist"]),
+  verboseMode: z.boolean().default(true),
   botDisplayName: z.string().nullable().optional(),
 });
 


### PR DESCRIPTION
- Add per-agent "Verbosity" setting for Hermes agents on Slack                                                                                                                                                                    
    - New verbose_mode field on agent_slack_config, controlling Hermes's display.platforms.slack.interim_assistant_messages (previously hardcoded off, silently suppressing all mid-turn narration for every agent)                 
    - Defaults to Verbose (on) for new and existing (backfilled) agents                                                                                                                                                             
    - Configurable in two places: the hire dialog's Details step, and the config drawer's Channels tab — both rendered as a native select (Verbose / Concise), only shown for Hermes agents (no-op for OpenClaw)                    
    - Helper copy: "the agent announces what it's about to do at each step"                                                                                                                                                         
    - Takes effect on next agent start (ConfigMap is recreated, not patched, on start_agent)                                                                                                                                        
  - Backend                                                                                                                                                                                                                         
    - Migration d7e8f9a0b1c2: adds verbose_mode BOOLEAN NOT NULL DEFAULT true to agent_slack_config                                                                                                                                 
    - AgentCreate.slack_verbose_mode / AgentUpdate.slack_verbose_mode / AgentSlackConfigRead.verbose_mode wired through create, PATCH, and read paths                                                                               
    - build_hermes_config(..., verbose_mode: bool = True) now drives interim_assistant_messages; tool_progress and busy_ack_detail remain hardcoded off for Slack                                                                   
    - Teams agents rejected on this field via existing _SLACK_CONFIG_FIELDS 422 guard                                                                                                                                               
  - Frontend                                                                                                                                                                                                                        
    - AgentSlackConfigSchema.verboseMode, CreateAgentData.slackVerboseMode, UpdateAgentData.slackVerboseMode                                                                                                                        
    - New Verbosity <select> in hire-dialog-steps.tsx (DetailsStep) and slack-config-panel.tsx, both gated on agentType === "hermes"                                                                                                
  - Tests                                                                                                                                                                                                                           
    - Unit: default-verbose and concise-override cases in test_hermes_builders.py                                                                                                                                                   
    - Integration: create/PATCH round-trip, ConfigMap YAML assertions for both verbose and concise modes in test_agents.py                                                                                                          