### PR TITLE
AF-147: wire transactional email config into the API deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,6 +173,9 @@ jobs:
           AGENT_TOKEN_ENCRYPTION_KEY: ${{ secrets.AGENT_TOKEN_ENCRYPTION_KEY }}
           ENVIRONMENT: production
           WEB_APP_URL: ${{ vars.WEB_APP_URL }}
+          EMAIL_SERVER_CREDENTIAL: ${{ secrets.EMAIL_SERVER_CREDENTIAL }}
+          EMAIL_SMTP_SERVER: ${{ vars.EMAIL_SMTP_SERVER }}
+          EMAIL_FROM_ADDRESS: ${{ vars.EMAIL_FROM_ADDRESS }}
           API_HOST: ${{ vars.API_HOST }}
           UI_HOST: ${{ vars.UI_HOST }}
           KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.28.0"

--- a/helm/agentfarm-api/templates/secret.yaml
+++ b/helm/agentfarm-api/templates/secret.yaml
@@ -18,3 +18,7 @@ stringData:
   AGENT_TOKEN_ENCRYPTION_KEY: {{ .Values.agentTokenEncryptionKey | required "agentTokenEncryptionKey is required" | quote }}
   ENVIRONMENT: {{ .Values.environment | required "environment is required" | quote }}
   WEB_APP_URL: {{ .Values.webAppUrl | required "webAppUrl is required" | quote }}
+  # Optional: unset leaves email delivery disabled (the app degrades gracefully).
+  EMAIL_SERVER_CREDENTIAL: {{ .Values.emailServerCredential | default "" | quote }}
+  EMAIL_SMTP_SERVER: {{ .Values.emailSmtpServer | default "" | quote }}
+  EMAIL_FROM_ADDRESS: {{ .Values.emailFromAddress | default "" | quote }}

--- a/helm/agentfarm-api/values.yaml
+++ b/helm/agentfarm-api/values.yaml
@@ -26,6 +26,13 @@ agentTokenEncryptionKey: ""
 environment: ""
 webAppUrl: ""
 
+# Transactional email (invites, password reset, verification). Leave blank to disable
+# email delivery — the app logs a warning and no-ops sends. Both credential and SMTP
+# server must be set for delivery to be enabled.
+emailServerCredential: ""
+emailSmtpServer: ""
+emailFromAddress: ""
+
 litellmBaseUrl: "http://litellm:4000"
 agentLitellmBaseUrl: "http://litellm:4000"
 

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -86,6 +86,12 @@ releases:
         value: {{ env "ENVIRONMENT" | required "ENVIRONMENT is required" | quote }}
       - name: webAppUrl
         value: {{ env "WEB_APP_URL" | required "WEB_APP_URL is required" | quote }}
+      - name: emailServerCredential
+        value: {{ env "EMAIL_SERVER_CREDENTIAL" | default "" | quote }}
+      - name: emailSmtpServer
+        value: {{ env "EMAIL_SMTP_SERVER" | default "" | quote }}
+      - name: emailFromAddress
+        value: {{ env "EMAIL_FROM_ADDRESS" | default "" | quote }}
       - name: apiExternalUrl
         value: {{ printf "https://%s" (env "API_HOST" | required "API_HOST is required" | splitList "," | first | trim) | quote }}
       - name: kubeconfigB64


### PR DESCRIPTION
The chart never surfaced EMAIL_* env, so invites/password-reset/verification silently no-op in the cluster (is_email_delivery_enabled is False). Thread the config through the deploy chain:
- deploy.yml passes EMAIL_SERVER_CREDENTIAL (secret) + EMAIL_SMTP_SERVER / EMAIL_FROM_ADDRESS (vars) to the helmfile sync.
- helmfile maps them to chart values (empty default, not required).
- values.yaml adds emailServerCredential/emailSmtpServer/emailFromAddress ("").
- secret.yaml templates EMAIL_SERVER_CREDENTIAL/EMAIL_SMTP_SERVER/ EMAIL_FROM_ADDRESS into the envFrom Secret.
- Bump agentfarm-api chart version 0.5.0 -> 0.5.1 (templates/values changed; appVersion unchanged, no app code change).

Unset leaves email disabled and the app degrades gracefully, so the deploy does not hard-fail before the secrets exist.

Required repo config (new):
- GitHub Secret: EMAIL_SERVER_CREDENTIAL (SMTP login, e.g. user:password)
- GitHub Variables: EMAIL_SMTP_SERVER (host:port), EMAIL_FROM_ADDRESS (optional)