### PR TITLE
Af 149 create a staging branch and deployment

### DIFF
--- a/.env.deploy.spec
+++ b/.env.deploy.spec
@@ -6,6 +6,12 @@
 # For k3s: copy /etc/rancher/k3s/k3s.yaml somewhere readable and point here.
 KUBECONFIG=$HOME/.kube/config
 
+# Target namespace. Defaults to agent-farm. helmfile reads this, so every release
+# (plus its secrets/services/ingresses) lands here. For a separate STAGING stack,
+# set NAMESPACE=agent-farm-staging, use the -staging image tags below, and point
+# deploy.sh's `kubectl apply` line at k8s/agent-farm-user.staging.yaml.
+NAMESPACE=agent-farm
+
 # ── Container registry ───────────────────────────────────────────────────────
 REGISTRY_PREFIX=registry.k8s.aai-labs.com
 REGISTRY_SERVER=registry.k8s.aai-labs.com
@@ -21,6 +27,8 @@ HERMES_IMAGE_REPOSITORY=agentfarm-hermes-base
 OPENCLAW_IMAGE_REPOSITORY=agentfarm-openclaw-base
 
 # ── Image tags (pin to specific versions for a real deploy) ──────────────────
+# For a staging deploy, suffix each with -staging (e.g. 0.13.0-staging); staging
+# builds its own images so it never clobbers prod's tags.
 API_IMAGE_TAG=0.13.0
 UI_IMAGE_TAG=0.13.0
 OPENCLAW_IMAGE_TAG=0.3.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,12 @@ jobs:
                 echo "ENVIRONMENT=staging"
                 echo "IMAGE_SUFFIX=-staging"
                 echo "PUSH_LATEST=false"
+                # Namespace is pre-created and the deploy SA is namespace-scoped
+                # (can't create cluster-scoped namespaces).
+                echo "CREATE_NAMESPACE=false"
+                # litellm-key hook runs as the deploy SA (already has secret perms)
+                # instead of the out-of-band agent-farm-user.
+                echo "LITELLM_KEY_SERVICE_ACCOUNT=agent-farm-staging-user"
                 echo "API_HOST=${{ vars.STAGING_API_HOST }}"
                 echo "UI_HOST=${{ vars.STAGING_UI_HOST }}"
                 echo "WEB_APP_URL=${{ vars.STAGING_WEB_APP_URL }}"
@@ -38,6 +44,8 @@ jobs:
                 echo "ENVIRONMENT=production"
                 echo "IMAGE_SUFFIX="
                 echo "PUSH_LATEST=true"
+                echo "CREATE_NAMESPACE=true"
+                echo "LITELLM_KEY_SERVICE_ACCOUNT=agent-farm-user"
                 echo "API_HOST=${{ vars.API_HOST }}"
                 echo "UI_HOST=${{ vars.UI_HOST }}"
                 echo "WEB_APP_URL=${{ vars.WEB_APP_URL }}"
@@ -200,6 +208,10 @@ jobs:
           KUBECONFIG: /home/runner/.kube/config
           # Target namespace, resolved from the branch (agent-farm / agent-farm-staging).
           NAMESPACE: ${{ env.NAMESPACE }}
+          # false on staging (namespace pre-exists, SA is namespace-scoped).
+          CREATE_NAMESPACE: ${{ env.CREATE_NAMESPACE }}
+          # SA the litellm-key hook runs as (staging: the namespace-scoped deploy SA).
+          LITELLM_KEY_SERVICE_ACCOUNT: ${{ env.LITELLM_KEY_SERVICE_ACCOUNT }}
           API_IMAGE_TAG: ${{ env.API_IMAGE_TAG }}
           UI_IMAGE_TAG: ${{ env.UI_IMAGE_TAG }}
           OPENCLAW_IMAGE_TAG: ${{ env.OPENCLAW_IMAGE_TAG }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,41 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Resolve per-environment config from the branch this was dispatched from.
+      # staging -> agent-farm-staging namespace, -staging image tags, no :latest,
+      # STAGING_ hosts. main -> production. Any other branch is rejected so a
+      # feature branch can never deploy to prod.
+      - name: Resolve environment
+        run: |
+          case "${{ github.ref_name }}" in
+            staging)
+              {
+                echo "NAMESPACE=agent-farm-staging"
+                echo "ENVIRONMENT=staging"
+                echo "IMAGE_SUFFIX=-staging"
+                echo "PUSH_LATEST=false"
+                echo "API_HOST=${{ vars.STAGING_API_HOST }}"
+                echo "UI_HOST=${{ vars.STAGING_UI_HOST }}"
+                echo "WEB_APP_URL=${{ vars.STAGING_WEB_APP_URL }}"
+              } >> "$GITHUB_ENV"
+              ;;
+            main)
+              {
+                echo "NAMESPACE=agent-farm"
+                echo "ENVIRONMENT=production"
+                echo "IMAGE_SUFFIX="
+                echo "PUSH_LATEST=true"
+                echo "API_HOST=${{ vars.API_HOST }}"
+                echo "UI_HOST=${{ vars.UI_HOST }}"
+                echo "WEB_APP_URL=${{ vars.WEB_APP_URL }}"
+              } >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "::error::Deploy is only allowed from 'staging' or 'main' (got '${{ github.ref_name }}')."
+              exit 1
+              ;;
+          esac
+
       - name: Verify component workflows are green
         env:
           GH_TOKEN: ${{ github.token }}
@@ -39,12 +74,14 @@ jobs:
           check_workflow "openclaw-base.yml"
           check_workflow "hermes-base.yml"
 
+      # Tags carry the env's IMAGE_SUFFIX (empty on main, -staging on staging) so
+      # staging builds/deploys its own images and never clobbers prod's tags.
       - name: Read image versions
         run: |
-          echo "API_IMAGE_TAG=$(grep '^\s*appVersion:' helm/agentfarm-api/Chart.yaml | awk '{print $2}' | tr -d '"')" >> $GITHUB_ENV
-          echo "UI_IMAGE_TAG=$(grep '^\s*appVersion:' helm/agentfarm-ui/Chart.yaml | awk '{print $2}' | tr -d '"')" >> $GITHUB_ENV
-          echo "OPENCLAW_IMAGE_TAG=$(cat openclaw-base/VERSION)" >> $GITHUB_ENV
-          echo "HERMES_IMAGE_TAG=$(cat hermes-base/VERSION)" >> $GITHUB_ENV
+          echo "API_IMAGE_TAG=$(grep '^\s*appVersion:' helm/agentfarm-api/Chart.yaml | awk '{print $2}' | tr -d '"')${IMAGE_SUFFIX}" >> $GITHUB_ENV
+          echo "UI_IMAGE_TAG=$(grep '^\s*appVersion:' helm/agentfarm-ui/Chart.yaml | awk '{print $2}' | tr -d '"')${IMAGE_SUFFIX}" >> $GITHUB_ENV
+          echo "OPENCLAW_IMAGE_TAG=$(cat openclaw-base/VERSION)${IMAGE_SUFFIX}" >> $GITHUB_ENV
+          echo "HERMES_IMAGE_TAG=$(cat hermes-base/VERSION)${IMAGE_SUFFIX}" >> $GITHUB_ENV
 
       - name: Install Helm
         run: |
@@ -71,25 +108,29 @@ jobs:
         run: |
           docker build \
             -t '${{ vars.REGISTRY_URL }}/agentfarm-api:${{ env.API_IMAGE_TAG }}' \
-            -t '${{ vars.REGISTRY_URL }}/agentfarm-api:latest' \
             -f api/Dockerfile \
             .
           docker push '${{ vars.REGISTRY_URL }}/agentfarm-api:${{ env.API_IMAGE_TAG }}'
-          docker push '${{ vars.REGISTRY_URL }}/agentfarm-api:latest'
+          if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
+            docker tag '${{ vars.REGISTRY_URL }}/agentfarm-api:${{ env.API_IMAGE_TAG }}' '${{ vars.REGISTRY_URL }}/agentfarm-api:latest'
+            docker push '${{ vars.REGISTRY_URL }}/agentfarm-api:latest'
+          fi
 
       - name: Extract primary API host
-        run: echo "PRIMARY_API_HOST=$(echo '${{ vars.API_HOST }}' | cut -d',' -f1 | tr -d ' ')" >> $GITHUB_ENV
+        run: echo "PRIMARY_API_HOST=$(echo '${{ env.API_HOST }}' | cut -d',' -f1 | tr -d ' ')" >> $GITHUB_ENV
 
       - name: Build and push UI image
         run: |
           docker build \
             --build-arg NEXT_PUBLIC_BACKEND_URL=https://${{ env.PRIMARY_API_HOST }} \
             -t '${{ vars.REGISTRY_URL }}/agentfarm-ui:${{ env.UI_IMAGE_TAG }}' \
-            -t '${{ vars.REGISTRY_URL }}/agentfarm-ui:latest' \
             -f ui/Dockerfile \
             ui/
           docker push '${{ vars.REGISTRY_URL }}/agentfarm-ui:${{ env.UI_IMAGE_TAG }}'
-          docker push '${{ vars.REGISTRY_URL }}/agentfarm-ui:latest'
+          if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
+            docker tag '${{ vars.REGISTRY_URL }}/agentfarm-ui:${{ env.UI_IMAGE_TAG }}' '${{ vars.REGISTRY_URL }}/agentfarm-ui:latest'
+            docker push '${{ vars.REGISTRY_URL }}/agentfarm-ui:latest'
+          fi
 
       - name: Build, smoke test, and push hermes-base image
         env:
@@ -99,7 +140,6 @@ jobs:
           docker build \
             --secret id=gh_token,src=/tmp/gh_token \
             -t '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:${{ env.HERMES_IMAGE_TAG }}' \
-            -t '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:latest' \
             -f hermes-base/Dockerfile \
             hermes-base/
           rm -f /tmp/gh_token
@@ -108,7 +148,10 @@ jobs:
             '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:${{ env.HERMES_IMAGE_TAG }}' \
             /bin/sh /smoke-test.sh
           docker push '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:${{ env.HERMES_IMAGE_TAG }}'
-          docker push '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:latest'
+          if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
+            docker tag '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:${{ env.HERMES_IMAGE_TAG }}' '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:latest'
+            docker push '${{ vars.REGISTRY_URL }}/agentfarm-hermes-base:latest'
+          fi
 
       - name: Build, smoke test, and push openclaw-base image
         env:
@@ -118,7 +161,6 @@ jobs:
           docker build \
             --secret id=gh_token,src=/tmp/gh_token \
             -t '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:${{ env.OPENCLAW_IMAGE_TAG }}' \
-            -t '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:latest' \
             -f openclaw-base/Dockerfile \
             openclaw-base/
           rm -f /tmp/gh_token
@@ -127,7 +169,10 @@ jobs:
             '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:${{ env.OPENCLAW_IMAGE_TAG }}' \
             /bin/sh /smoke-test.sh
           docker push '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:${{ env.OPENCLAW_IMAGE_TAG }}'
-          docker push '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:latest'
+          if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
+            docker tag '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:${{ env.OPENCLAW_IMAGE_TAG }}' '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:latest'
+            docker push '${{ vars.REGISTRY_URL }}/agentfarm-openclaw-base:latest'
+          fi
 
       - name: Set up SSH tunnel to k3s
         run: |
@@ -147,41 +192,49 @@ jobs:
       - name: Set up kubeconfig
         run: |
           mkdir -p ~/.kube
-          printf '%s' '${{ secrets.KUBECONFIG_B64 }}' | base64 -d > ~/.kube/config
+          printf '%s' '${{ github.ref_name == 'staging' && secrets.STAGING_KUBECONFIG_B64 || secrets.KUBECONFIG_B64 }}' | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 
       - name: Helmfile sync
         env:
           KUBECONFIG: /home/runner/.kube/config
+          # Target namespace, resolved from the branch (agent-farm / agent-farm-staging).
+          NAMESPACE: ${{ env.NAMESPACE }}
           API_IMAGE_TAG: ${{ env.API_IMAGE_TAG }}
           UI_IMAGE_TAG: ${{ env.UI_IMAGE_TAG }}
           OPENCLAW_IMAGE_TAG: ${{ env.OPENCLAW_IMAGE_TAG }}
           HERMES_IMAGE_TAG: ${{ env.HERMES_IMAGE_TAG }}
+          # DB user/db names are shared: each namespace has its own Postgres, so
+          # identical names don't collide. Only the passwords/keys are per-env.
           POSTGRES_APP_USER: ${{ vars.POSTGRES_APP_USER }}
-          POSTGRES_APP_PASSWORD: ${{ secrets.POSTGRES_APP_PASSWORD }}
+          POSTGRES_APP_PASSWORD: ${{ github.ref_name == 'staging' && secrets.STAGING_POSTGRES_APP_PASSWORD || secrets.POSTGRES_APP_PASSWORD }}
           POSTGRES_APP_DB: ${{ vars.POSTGRES_APP_DB }}
           POSTGRES_LITELLM_USER: ${{ vars.POSTGRES_LITELLM_USER }}
-          POSTGRES_LITELLM_PASSWORD: ${{ secrets.POSTGRES_LITELLM_PASSWORD }}
+          POSTGRES_LITELLM_PASSWORD: ${{ github.ref_name == 'staging' && secrets.STAGING_POSTGRES_LITELLM_PASSWORD || secrets.POSTGRES_LITELLM_PASSWORD }}
           POSTGRES_LITELLM_DB: ${{ vars.POSTGRES_LITELLM_DB }}
-          LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+          LITELLM_MASTER_KEY: ${{ github.ref_name == 'staging' && secrets.STAGING_LITELLM_MASTER_KEY || secrets.LITELLM_MASTER_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           AGENT_DEFAULT_MODEL: ${{ vars.AGENT_DEFAULT_MODEL }}
           AGENT_MODEL_ALLOWLIST: ${{ vars.AGENT_MODEL_ALLOWLIST }}
           STORAGE_CLASS: ${{ vars.STORAGE_CLASS }}
-          SECRET_SIGNING_KEY: ${{ secrets.SECRET_SIGNING_KEY }}
-          SUPER_USER_CREDENTIALS: ${{ secrets.SUPER_USER_CREDENTIALS }}
-          AGENT_TOKEN_ENCRYPTION_KEY: ${{ secrets.AGENT_TOKEN_ENCRYPTION_KEY }}
-          ENVIRONMENT: production
-          WEB_APP_URL: ${{ vars.WEB_APP_URL }}
+          SECRET_SIGNING_KEY: ${{ github.ref_name == 'staging' && secrets.STAGING_SECRET_SIGNING_KEY || secrets.SECRET_SIGNING_KEY }}
+          SUPER_USER_CREDENTIALS: ${{ github.ref_name == 'staging' && secrets.STAGING_SUPER_USER_CREDENTIALS || secrets.SUPER_USER_CREDENTIALS }}
+          AGENT_TOKEN_ENCRYPTION_KEY: ${{ github.ref_name == 'staging' && secrets.STAGING_AGENT_TOKEN_ENCRYPTION_KEY || secrets.AGENT_TOKEN_ENCRYPTION_KEY }}
+          ENVIRONMENT: ${{ env.ENVIRONMENT }}
+          WEB_APP_URL: ${{ env.WEB_APP_URL }}
+          # Google OAuth client is shared; add the staging redirect URI in GCP Console.
           GOOGLE_CLOUD_CLIENT_ID: ${{ vars.GOOGLE_CLOUD_CLIENT_ID }}
           GOOGLE_CLOUD_CLIENT_SECRET: ${{ secrets.GOOGLE_CLOUD_CLIENT_SECRET }}
-          EMAIL_SERVER_CREDENTIAL: ${{ secrets.EMAIL_SERVER_CREDENTIAL }}
-          EMAIL_SMTP_SERVER: ${{ vars.EMAIL_SMTP_SERVER }}
-          EMAIL_FROM_ADDRESS: ${{ vars.EMAIL_FROM_ADDRESS }}
-          API_HOST: ${{ vars.API_HOST }}
-          UI_HOST: ${{ vars.UI_HOST }}
-          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
-          POD_KUBECONFIG_B64: ${{ secrets.POD_KUBECONFIG_B64 }}
+          # Email is prod-only. Inverted condition so the empty branch is intended
+          # on staging (a plain `staging && STAGING_x || x` would fall back to prod
+          # when STAGING_x is empty).
+          EMAIL_SERVER_CREDENTIAL: ${{ github.ref_name == 'main' && secrets.EMAIL_SERVER_CREDENTIAL || '' }}
+          EMAIL_SMTP_SERVER: ${{ github.ref_name == 'main' && vars.EMAIL_SMTP_SERVER || '' }}
+          EMAIL_FROM_ADDRESS: ${{ github.ref_name == 'main' && vars.EMAIL_FROM_ADDRESS || '' }}
+          API_HOST: ${{ env.API_HOST }}
+          UI_HOST: ${{ env.UI_HOST }}
+          KUBECONFIG_B64: ${{ github.ref_name == 'staging' && secrets.STAGING_KUBECONFIG_B64 || secrets.KUBECONFIG_B64 }}
+          POD_KUBECONFIG_B64: ${{ github.ref_name == 'staging' && secrets.STAGING_POD_KUBECONFIG_B64 || secrets.POD_KUBECONFIG_B64 }}
           REGISTRY_SERVER: ${{ vars.REGISTRY_URL }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,6 @@ jobs:
                 echo "ENVIRONMENT=staging"
                 echo "IMAGE_SUFFIX=-staging"
                 echo "PUSH_LATEST=false"
-                # Namespace is pre-created and the deploy SA is namespace-scoped
-                # (can't create cluster-scoped namespaces).
-                echo "CREATE_NAMESPACE=false"
                 # litellm-key hook runs as the deploy SA (already has secret perms)
                 # instead of the out-of-band agent-farm-user.
                 echo "LITELLM_KEY_SERVICE_ACCOUNT=agent-farm-staging-user"
@@ -44,7 +41,6 @@ jobs:
                 echo "ENVIRONMENT=production"
                 echo "IMAGE_SUFFIX="
                 echo "PUSH_LATEST=true"
-                echo "CREATE_NAMESPACE=true"
                 echo "LITELLM_KEY_SERVICE_ACCOUNT=agent-farm-user"
                 echo "API_HOST=${{ vars.API_HOST }}"
                 echo "UI_HOST=${{ vars.UI_HOST }}"
@@ -208,8 +204,6 @@ jobs:
           KUBECONFIG: /home/runner/.kube/config
           # Target namespace, resolved from the branch (agent-farm / agent-farm-staging).
           NAMESPACE: ${{ env.NAMESPACE }}
-          # false on staging (namespace pre-exists, SA is namespace-scoped).
-          CREATE_NAMESPACE: ${{ env.CREATE_NAMESPACE }}
           # SA the litellm-key hook runs as (staging: the namespace-scoped deploy SA).
           LITELLM_KEY_SERVICE_ACCOUNT: ${{ env.LITELLM_KEY_SERVICE_ACCOUNT }}
           API_IMAGE_TAG: ${{ env.API_IMAGE_TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ dist/
 .env
 .env.test
 .env.deploy
+# Per-environment deploy configs hold real secrets; keep only the tracked spec.
+.env.deploy.*
+!.env.deploy.spec
 
 # Log files
 *.log

--- a/agent_plans/AF-149_plan.md
+++ b/agent_plans/AF-149_plan.md
@@ -1,0 +1,262 @@
+# Plan: Staging branch & deployment (AF-149)
+
+## Context
+
+The repo had exactly one environment. Every Helm release in `helmfile.yaml.gotmpl`
+was pinned to `namespace: agent-farm`, and `deploy.yml` (a `workflow_dispatch`-only job)
+built four images, pushed `<ver>` + `:latest`, then `helmfile sync`ed into that single
+namespace with `ENVIRONMENT: production` hardcoded and prod-only secrets/vars.
+
+We want a **staging** environment that:
+- has the repo's **default branch = `staging`**,
+- deploys via the existing workflow **when dispatched from `staging`**,
+- runs as a **fully separate stack with its own DB**, and
+- is reachable at its **own hostname**.
+
+**Approach: a separate namespace `agent-farm-staging`,** driven by a `NAMESPACE` env var in
+helmfile, plus `STAGING_`-prefixed GitHub secrets/vars selected by a branch check in
+`deploy.yml`. A separate namespace is the cheapest correct isolation: Kubernetes short-name
+service DNS is namespace-relative, so the hardcoded connection strings (`postgres-app`,
+`postgres-litellm`, `litellm:4000`) and fixed secret names (`registry-pull-secret`,
+`agent-farm-user-kubeconfig`, `litellm-api-key`) resolve correctly per-namespace and never
+collide — **no chart/DNS edits**. It also lets the staging API pod hold a kubeconfig scoped
+to `agent-farm-staging`, so it structurally cannot touch prod's agent workloads.
+
+GitHub Environments are **not** usable (Free plan + private repo can't gate them), so
+per-environment config lives in `STAGING_`-prefixed secrets/vars chosen at runtime via a
+ternary on `github.ref_name`.
+
+### Locked decisions (confirmed with user)
+
+| Topic | Decision |
+|---|---|
+| Isolation | Separate namespace `agent-farm-staging` |
+| Trigger | Manual `workflow_dispatch`, dispatched from `staging` |
+| Prod branch | `main` stays the production deploy source |
+| Default branch | Flip GitHub default to `staging` |
+| Hostnames | UI `agent-farm-staging.k8s.aai-labs.com`, API `api.agent-farm-staging.k8s.aai-labs.com` (hyphens — Let's Encrypt rejects underscores) |
+| Image tags | **All four** images (api, ui, openclaw-base, hermes-base) suffixed `-staging`; do **not** push `:latest` from staging (each env builds its own base images, whose installed contents can diverge) |
+| `ENVIRONMENT` | `staging` (cosmetic; no app branching keys on it) |
+| Email on staging | **Disabled** (no real invite/reset mail from staging) |
+| Google OAuth (Gmail) | **Reuse the prod client**; add the staging redirect URI in Google Cloud Console (else leave blank to disable Gmail on staging) |
+| First bring-up | **Local `deploy.sh`**, then wire CI |
+
+**Pre-done outside this repo:** the `agent-farm-staging` namespace and a staging kubeconfig
+both exist. RBAC (`agent-farm-user` SA/Role/RoleBinding) state is unknown — the first
+`deploy.sh` run applies it idempotently.
+
+---
+
+## PART 1 — Code changes in this repo
+
+### A. Chart — API namespace isolation (the linchpin)
+
+`helm/agentfarm-api/templates/deployment.yaml`: add to the container `env:` list
+
+```yaml
+- name: K8S_NAMESPACE
+  value: {{ .Release.Namespace }}
+```
+
+Without this, `Config.k8s_namespace` (`api/core/config.py:33`) falls back to its hardcoded
+`"agent-farm"` and the staging pod would create agent Deployments/Services/PVCs/Secrets in
+the **prod** namespace (used across `api/domains/agents/service.py`,
+`conversations/service.py`, `tool_calls/sync_service.py`, `litellm/client.py`). Correct for
+prod too (`agent-farm` → `agent-farm`).
+
+### B. Helmfile — parameterize namespace + pass image tags
+
+`helmfile.yaml.gotmpl`:
+1. On **all 5 releases**, `namespace: {{ env "NAMESPACE" | default "agent-farm" }}`.
+2. In **all 3 `needs:` blocks**, qualify with the same expr, e.g.
+   `- {{ env "NAMESPACE" | default "agent-farm" }}/postgres-app` (helmfile `needs` are
+   `<namespace>/<release>`; a templated namespace with un-templated needs breaks resolution).
+3. Add `image.tag` set entries to **agentfarm-api** and **agentfarm-ui**:
+   `value: {{ env "API_IMAGE_TAG" | default "" | quote }}` (ui → `UI_IMAGE_TAG`). Empty keeps
+   the chart's `| default .Chart.AppVersion` fallback, so prod is unchanged. openclaw/hermes
+   tags already flow via existing `openclawImage.tag`/`hermesImage.tag` set entries.
+
+### C. Staging namespace bootstrap manifest (RBAC only)
+
+New file `k8s/agent-farm-user.staging.yaml`: the `agent-farm-user` **ServiceAccount + Role +
+RoleBinding** for `agent-farm-staging` — **omitting the `Namespace` object** (it already
+exists; a namespace-scoped kubeconfig can't GET/create a cluster-scoped Namespace, which
+would make `kubectl apply` fail). This is the identity the litellm-key pre-install Job runs as
+(`litellm-key-job.yaml:20` hardcodes `serviceAccountName: agent-farm-user`, namespaced to
+`.Release.Namespace`). Idempotent.
+
+### D. CI — `.github/workflows/deploy.yml`
+
+1. **New "Resolve environment" step** (after Checkout): branch on `github.ref_name`, write
+   non-secret env to `$GITHUB_ENV`, fail on anything else:
+   - `staging` → `NAMESPACE=agent-farm-staging ENVIRONMENT=staging IMAGE_SUFFIX=-staging
+     PUSH_LATEST=false`, hosts/URL from `vars.STAGING_*`.
+   - `main` → `NAMESPACE=agent-farm ENVIRONMENT=production IMAGE_SUFFIX= PUSH_LATEST=true`,
+     hosts/URL from `vars.*`.
+   - else → `exit 1` (blocks deploys from feature branches).
+2. **"Read image versions"**: append `${IMAGE_SUFFIX}` to all four tags.
+3. **All four build/push steps**: push `<ver>` (already suffixed); only tag & push `:latest`
+   `if [ "${{ env.PUSH_LATEST }}" = "true" ]`.
+4. **"Extract primary API host"**: read `${{ env.API_HOST }}` (not `vars.API_HOST`).
+5. **"Set up kubeconfig"**: per-env decode —
+   `${{ github.ref_name == 'staging' && secrets.STAGING_KUBECONFIG_B64 || secrets.KUBECONFIG_B64 }}`.
+6. **"Helmfile sync" `env:` block**: add `NAMESPACE`; switch `ENVIRONMENT`, `WEB_APP_URL`,
+   `API_HOST`, `UI_HOST` to resolved `env.*`; per-env secrets via
+   `${{ github.ref_name == 'staging' && secrets.STAGING_X || secrets.X }}` for
+   `POSTGRES_APP_PASSWORD`, `POSTGRES_LITELLM_PASSWORD`, `LITELLM_MASTER_KEY`,
+   `SECRET_SIGNING_KEY`, `SUPER_USER_CREDENTIALS`, `AGENT_TOKEN_ENCRYPTION_KEY`,
+   `KUBECONFIG_B64`, `POD_KUBECONFIG_B64`; email via the **inverted** pattern
+   `${{ github.ref_name == 'main' && <prodValue> || '' }}` (so staging = empty/disabled, not
+   an accidental prod fallback — the `&& || ` idiom falls back to the RHS when the LHS is
+   empty). Shared refs (`REGISTRY_*`, `BASTION_SSH_KEY`, `OPENROUTER_API_KEY`, `STORAGE_CLASS`,
+   `AGENT_DEFAULT_MODEL`, `AGENT_MODEL_ALLOWLIST`, `GOOGLE_CLOUD_CLIENT_ID/SECRET`, DB
+   user/db names) left untouched.
+
+### E. `deploy.sh`, env spec & docs
+
+- `deploy.sh`: no code change — for the staging run you manually point its
+  `kubectl apply -f k8s/agent-farm-user.yaml` at `k8s/agent-farm-user.staging.yaml`. It
+  already `set -a` exports the env file, so `NAMESPACE` + the four `*_IMAGE_TAG`s flow into
+  helmfile.
+- `.env.deploy.spec`: added `NAMESPACE` + commented staging guidance (the `-staging` tag
+  convention, the user-manifest line).
+- `CLAUDE.md`: added a "Staging environment" section + the `STAGING_` secrets/vars list.
+
+### Files changed / created
+- `helm/agentfarm-api/templates/deployment.yaml` — add `K8S_NAMESPACE` (§A)
+- `helmfile.yaml.gotmpl` — namespace + needs templating, api/ui `image.tag` (§B)
+- `k8s/agent-farm-user.staging.yaml` — **new**, RBAC-only (§C)
+- `.github/workflows/deploy.yml` — resolve/guard, suffix all 4 tags, `:latest` gate, per-env
+  kubeconfig decode, env-selected values, ternary/inverted secrets (§D)
+- `.env.deploy.spec`, `CLAUDE.md` — staging docs (§E). `.env.deploy.staging` is created
+  locally and **gitignored** (never committed).
+
+No changes to postgres/litellm/ui templates, connection strings, or the litellm-key job —
+namespace-relative resolution handles them.
+
+---
+
+## PART 2 — External setup checklist (NOT in this codebase — done by the operator)
+
+### 2.1 GitHub → Settings → Secrets and variables → Actions → **Variables**
+| Variable | Value |
+|---|---|
+| `STAGING_API_HOST` | `api.agent-farm-staging.k8s.aai-labs.com` |
+| `STAGING_UI_HOST` | `agent-farm-staging.k8s.aai-labs.com` |
+| `STAGING_WEB_APP_URL` | `https://agent-farm-staging.k8s.aai-labs.com` |
+
+*Reused as-is (no staging copy):* `REGISTRY_URL`, `REGISTRY_USERNAME`, `POSTGRES_APP_USER`,
+`POSTGRES_APP_DB`, `POSTGRES_LITELLM_USER`, `POSTGRES_LITELLM_DB`, `AGENT_DEFAULT_MODEL`,
+`AGENT_MODEL_ALLOWLIST`, `STORAGE_CLASS`, `GOOGLE_CLOUD_CLIENT_ID`. (`EMAIL_SMTP_SERVER`,
+`EMAIL_FROM_ADDRESS` are ignored on staging — email disabled.)
+
+### 2.2 GitHub → **Secrets** (generate fresh, distinct from prod)
+| Secret | How to produce |
+|---|---|
+| `STAGING_POSTGRES_APP_PASSWORD` | `openssl rand -hex 24` |
+| `STAGING_POSTGRES_LITELLM_PASSWORD` | `openssl rand -hex 24` |
+| `STAGING_LITELLM_MASTER_KEY` | `echo "sk-$(openssl rand -hex 24)"` |
+| `STAGING_SECRET_SIGNING_KEY` | `openssl rand -hex 32` |
+| `STAGING_SUPER_USER_CREDENTIALS` | `admin@example.com:<password>` |
+| `STAGING_AGENT_TOKEN_ENCRYPTION_KEY` | `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"` |
+| `STAGING_KUBECONFIG_B64` | `base64 -w0 <staging-kubeconfig>` (CI runner → helmfile sync) |
+| `STAGING_POD_KUBECONFIG_B64` | `base64 -w0 <staging-kubeconfig>` (baked into the API pod; **same value is fine**) |
+
+> ⚠️ Staging DB/LiteLLM passwords + keys are set **once at first bring-up** and baked into the
+> namespace's secrets + Postgres data dir. Use the **same values** in `.env.deploy.staging`
+> and in these GitHub secrets, or a later CI sync writes a new app-DB secret that no longer
+> matches the password already initialized in the Postgres PVC (auth failures).
+
+*Reused as-is:* `REGISTRY_PASSWORD`, `AAI_CLI_REPO_ACCESS_TOKEN`, `BASTION_SSH_KEY`,
+`OPENROUTER_API_KEY`, `GOOGLE_CLOUD_CLIENT_SECRET`. `EMAIL_SERVER_CREDENTIAL` is used only on
+`main`.
+
+### 2.3 GitHub → repo settings
+- Create branch `staging` from `main`, push it.
+- `gh repo edit aai-labs/agent-farm --default-branch staging` (or Settings → General).
+  ⚠️ Changes new-PR base + fresh `git clone` checkout for the whole team — coordinate first.
+
+### 2.4 Cluster (kubectl, one-time)
+- **RBAC (state unknown):** ensure `agent-farm-user` SA/Role/RoleBinding exist in
+  `agent-farm-staging`. The first `deploy.sh` run applies `k8s/agent-farm-user.staging.yaml`
+  for you. Pre-check: `kubectl -n agent-farm-staging get sa agent-farm-user`. Manual:
+  `kubectl apply -f k8s/agent-farm-user.staging.yaml`.
+- The staging kubeconfig must be **namespace-admin** in `agent-farm-staging` (create
+  Deployments/StatefulSets/Services/PVCs/Secrets/Ingresses/Jobs + the SA/Role/RoleBinding).
+
+### 2.5 DNS & TLS
+- **DNS:** the `*.k8s.aai-labs.com` wildcard already covers both new hosts — nothing to do
+  (confirm the wildcard; else add A/CNAME for `agent-farm-staging` + `api.agent-farm-staging`).
+- **TLS:** cert-manager + `letsencrypt-http01` issues on-demand per host — nothing to do
+  beyond the hosts resolving publicly.
+
+### 2.6 Google Cloud Console (only if Gmail on staging is wanted)
+- Add `https://agent-farm-staging.k8s.aai-labs.com/api/v1/integrations/google/callback` to the
+  existing OAuth "Web application" client's **Authorized redirect URIs**. Otherwise leave
+  `GOOGLE_CLOUD_CLIENT_ID/SECRET` blank for staging.
+
+### 2.7 Shared-resource acknowledgements
+- Staging shares the **OpenRouter** account (billing) and the **container registry** (`aailabs/`
+  — now with `*-staging` tags). Acceptable for staging; flag if separate OpenRouter billing is
+  wanted.
+
+---
+
+## First bring-up runbook (local `deploy.sh`, then CI)
+
+1. **Build & push the four `*-staging` images** (deploy.sh does **not** build). Either a CI run
+   from `staging` (builds + pushes + syncs), or build manually
+   (`docker build -t registry.k8s.aai-labs.com/aailabs/agentfarm-<img>:<ver>-staging …` for
+   api/ui/hermes-base/openclaw-base; base builds need the `gh_token` secret), then push.
+2. **`.env.deploy.staging`** (copy `.env.deploy.spec`, gitignored): `NAMESPACE=agent-farm-staging`,
+   `ENVIRONMENT=staging`, the three staging hosts/URL, the four `*_IMAGE_TAG=<ver>-staging`, the
+   **same** staging passwords/keys as the GitHub secrets, `KUBECONFIG=<staging kubeconfig>`,
+   `POD_KUBECONFIG_B64=$(base64 -w0 <staging kubeconfig>)`, shared `REGISTRY_*`,
+   `OPENROUTER_API_KEY`, `STORAGE_CLASS=local-path`, (optional) Google client.
+3. **Point deploy.sh at the staging user-manifest** (edit its `kubectl apply` line →
+   `k8s/agent-farm-user.staging.yaml`).
+4. **Run:** `ENV_FILE=.env.deploy.staging bash deploy.sh`. Applies RBAC, then `helmfile sync
+   --wait` creates both Postgres, litellm, api, ui, ingresses + all in-namespace secrets in
+   `agent-farm-staging`.
+5. **Wire CI:** add the GitHub vars/secrets (§2.1–2.2), push `staging`, flip the default branch
+   (§2.3), dispatch `deploy.yml` from `staging`.
+
+---
+
+## Verification (done for the render steps)
+
+1. **Render (no cluster):** `helmfile -f helmfile.yaml.gotmpl template` with
+   `NAMESPACE=agent-farm-staging` + the four `*_IMAGE_TAG=<ver>-staging` → **✅ all 23 objects
+   `namespace: agent-farm-staging`**, api/ui + the pod's `OPENCLAW_IMAGE`/`HERMES_IMAGE` end in
+   `-staging`, `K8S_NAMESPACE=agent-farm-staging`. Re-run with no `NAMESPACE`/suffix → **✅ back
+   to `agent-farm`**, api/ui fall back to `AppVersion` (0.29.0 / 0.26.1), base images to
+   `latest`, `K8S_NAMESPACE=agent-farm` (prod unchanged).
+2. **Local k3s dry run** (optional): sync `NAMESPACE=agent-farm-staging` into local k3s.
+3. **First bring-up:** runbook → `kubectl get all -n agent-farm-staging` shows the full stack.
+4. **Reachability:** `curl https://api.agent-farm-staging.k8s.aai-labs.com/api/v1/health` healthy;
+   UI host loads over TLS.
+5. **Isolation proof:** create a test agent on staging → its pod is in `agent-farm-staging`, not
+   `agent-farm`.
+6. **Prod untouched:** `kubectl get all -n agent-farm` unchanged; prod images still unsuffixed; a
+   dispatch from `main` still targets `agent-farm` + pushes `:latest`.
+
+---
+
+## Implementation status
+
+**Code (Part 1): DONE** — all edits applied and verified via `helmfile template` for both
+staging and prod (verification step 1 ✅). Files: `helm/agentfarm-api/templates/deployment.yaml`,
+`helmfile.yaml.gotmpl`, `k8s/agent-farm-user.staging.yaml` (new), `.github/workflows/deploy.yml`,
+`.env.deploy.spec`, `CLAUDE.md`.
+
+**Operator (Part 2 + runbook): PENDING** — GitHub vars/secrets, default-branch flip, staging
+kubeconfig → `STAGING_*_KUBECONFIG_B64`, optional Google redirect URI, and the first `deploy.sh`
+bring-up.
+
+## Open items / risks
+- **Secret/password consistency** between `.env.deploy.staging` and the GitHub `STAGING_*`
+  secrets (see ⚠️ §2.2) — mismatches surface as Postgres/LiteLLM auth errors on a later sync.
+- **Default-branch flip** affects the whole team (PR base, fresh clones) — coordinate.
+- **Staging kubeconfig scope** — confirm it's namespace-admin; if not, one broader apply is
+  needed for the RBAC.
+- Staging **shares OpenRouter billing + the registry** with prod — acceptable for staging.

--- a/helm/agentfarm-api/templates/deployment.yaml
+++ b/helm/agentfarm-api/templates/deployment.yaml
@@ -41,6 +41,12 @@ spec:
             - secretRef:
                 name: {{ .Values.litellmApiKeySecretName }}
           env:
+            # The namespace this release runs in — the API creates agent
+            # workloads (Deployments/Services/PVCs/Secrets) here. Without it the
+            # app falls back to its hardcoded "agent-farm" default, so a staging
+            # pod would spawn agents into the prod namespace.
+            - name: K8S_NAMESPACE
+              value: {{ .Release.Namespace }}
             - name: K8S_KUBECONFIG_PATH
               value: /etc/kubeconfig/kubeconfig
             - name: OPENCLAW_IMAGE

--- a/helm/agentfarm-api/templates/litellm-key-job.yaml
+++ b/helm/agentfarm-api/templates/litellm-key-job.yaml
@@ -17,7 +17,7 @@ spec:
         {{- include "agentfarm-api.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: litellm-key-job
     spec:
-      serviceAccountName: agent-farm-user
+      serviceAccountName: {{ .Values.litellmKeyServiceAccountName | default "agent-farm-user" }}
       automountServiceAccountToken: true
       restartPolicy: Never
       containers:

--- a/helm/agentfarm-api/values.yaml
+++ b/helm/agentfarm-api/values.yaml
@@ -67,6 +67,12 @@ litellmApiKeySecretName: litellm-api-key
 # Pre-existing litellm Secret (used by hook Job to call /key/generate)
 litellmSecretName: litellm
 
+# ServiceAccount the litellm-key hook Job runs as (needs create/update on secrets).
+# Defaults to the out-of-band `agent-farm-user` (see k8s/agent-farm-user.yaml). Set
+# to the deploy identity's own SA when that SA already has secret perms and you can't
+# provision the agent-farm-user Role/RoleBinding (e.g. a namespace-scoped kubeconfig).
+litellmKeyServiceAccountName: agent-farm-user
+
 #  kubeconfig Secret for managing agent k8s resources
 kubeconfigSecretName: agent-farm-user-kubeconfig
 

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -1,5 +1,8 @@
 helmDefaults:
-  createNamespace: true
+  # Default true (prod bootstraps the namespace via helm). Set CREATE_NAMESPACE=false
+  # when the namespace is pre-created and the deploy identity is namespace-scoped
+  # (can't create cluster-scoped namespaces), e.g. staging's agent-farm-staging-user.
+  createNamespace: {{ env "CREATE_NAMESPACE" | default "true" }}
 
 releases:
   - name: postgres-app
@@ -68,6 +71,8 @@ releases:
         value: {{ env "API_IMAGE_REPOSITORY" | default "agentfarm-api" | quote }}
       - name: image.tag
         value: {{ env "API_IMAGE_TAG" | default "" | quote }}
+      - name: litellmKeyServiceAccountName
+        value: {{ env "LITELLM_KEY_SERVICE_ACCOUNT" | default "agent-farm-user" | quote }}
       - name: openclawImage.repository
         value: {{ env "OPENCLAW_IMAGE_REPOSITORY" | default "agentfarm-openclaw-base" | quote }}
       - name: openclawImage.tag

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -1,8 +1,10 @@
 helmDefaults:
-  # Default true (prod bootstraps the namespace via helm). Set CREATE_NAMESPACE=false
-  # when the namespace is pre-created and the deploy identity is namespace-scoped
-  # (can't create cluster-scoped namespaces), e.g. staging's agent-farm-staging-user.
-  createNamespace: {{ env "CREATE_NAMESPACE" | default "true" }}
+  # Every environment pre-creates its namespace out-of-band (staging ahead of
+  # time; prod via deploy.sh's `kubectl apply -f k8s/agent-farm-user.yaml`), and
+  # the deploy identities are namespace-scoped and can't create cluster-scoped
+  # namespaces. So helm must never attempt to create it — the target namespace
+  # always already exists.
+  createNamespace: false
 
 releases:
   - name: postgres-app

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -3,7 +3,7 @@ helmDefaults:
 
 releases:
   - name: postgres-app
-    namespace: agent-farm
+    namespace: {{ env "NAMESPACE" | default "agent-farm" }}
     chart: ./helm/postgres
     labels:
       name: postgres-app
@@ -22,7 +22,7 @@ releases:
         value: {{ env "POSTGRES_APP_DB" | required "POSTGRES_APP_DB is required" | quote }}
 
   - name: postgres-litellm
-    namespace: agent-farm
+    namespace: {{ env "NAMESPACE" | default "agent-farm" }}
     chart: ./helm/postgres
     labels:
       name: postgres-litellm
@@ -41,7 +41,7 @@ releases:
         value: {{ env "POSTGRES_LITELLM_DB" | required "POSTGRES_LITELLM_DB is required" | quote }}
 
   - name: litellm
-    namespace: agent-farm
+    namespace: {{ env "NAMESPACE" | default "agent-farm" }}
     chart: ./helm/litellm
     labels:
       name: litellm
@@ -53,11 +53,11 @@ releases:
       - name: databaseUrl
         value: {{ printf "postgresql://%s:%s@postgres-litellm:5432/%s" (env "POSTGRES_LITELLM_USER") (env "POSTGRES_LITELLM_PASSWORD") (env "POSTGRES_LITELLM_DB") | quote }}
     needs:
-      - agent-farm/postgres-app
-      - agent-farm/postgres-litellm
+      - {{ env "NAMESPACE" | default "agent-farm" }}/postgres-app
+      - {{ env "NAMESPACE" | default "agent-farm" }}/postgres-litellm
 
   - name: agentfarm-api
-    namespace: agent-farm
+    namespace: {{ env "NAMESPACE" | default "agent-farm" }}
     chart: ./helm/agentfarm-api
     labels:
       name: agentfarm-api
@@ -66,6 +66,8 @@ releases:
         value: {{ env "REGISTRY_PREFIX" | default "registry.k8s.aai-labs.com" | quote }}
       - name: image.repository
         value: {{ env "API_IMAGE_REPOSITORY" | default "agentfarm-api" | quote }}
+      - name: image.tag
+        value: {{ env "API_IMAGE_TAG" | default "" | quote }}
       - name: openclawImage.repository
         value: {{ env "OPENCLAW_IMAGE_REPOSITORY" | default "agentfarm-openclaw-base" | quote }}
       - name: openclawImage.tag
@@ -115,11 +117,11 @@ releases:
       - name: ingress.hosts
         value: {{ env "API_HOST" | required "API_HOST is required" | quote }}
     needs:
-      - agent-farm/postgres-app
-      - agent-farm/litellm
+      - {{ env "NAMESPACE" | default "agent-farm" }}/postgres-app
+      - {{ env "NAMESPACE" | default "agent-farm" }}/litellm
 
   - name: agentfarm-ui
-    namespace: agent-farm
+    namespace: {{ env "NAMESPACE" | default "agent-farm" }}
     chart: ./helm/agentfarm-ui
     labels:
       name: agentfarm-ui
@@ -128,7 +130,9 @@ releases:
         value: {{ env "REGISTRY_PREFIX" | default "registry.k8s.aai-labs.com" | quote }}
       - name: image.repository
         value: {{ env "UI_IMAGE_REPOSITORY" | default "agentfarm-ui" | quote }}
+      - name: image.tag
+        value: {{ env "UI_IMAGE_TAG" | default "" | quote }}
       - name: ingress.hosts
         value: {{ env "UI_HOST" | required "UI_HOST is required" | quote }}
     needs:
-      - agent-farm/agentfarm-api
+      - {{ env "NAMESPACE" | default "agent-farm" }}/agentfarm-api

--- a/k8s/agent-farm-user.staging.yaml
+++ b/k8s/agent-farm-user.staging.yaml
@@ -1,0 +1,37 @@
+# Staging cluster prerequisite for agent-farm, applied outside helm.
+#
+# Same purpose as k8s/agent-farm-user.yaml (the agent-farm-user ServiceAccount +
+# RBAC the API's litellm-key pre-install Job runs as), but scoped to the
+# agent-farm-staging namespace. The Namespace object is intentionally omitted:
+# agent-farm-staging is created out-of-band, and a namespace-scoped kubeconfig
+# can't GET/create a cluster-scoped Namespace — including it would make
+# `kubectl apply` fail. Applying this is idempotent — a no-op where it exists.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-farm-user
+  namespace: agent-farm-staging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-farm-user
+  namespace: agent-farm-staging
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-farm-user
+  namespace: agent-farm-staging
+subjects:
+  - kind: ServiceAccount
+    name: agent-farm-user
+    namespace: agent-farm-staging
+roleRef:
+  kind: Role
+  name: agent-farm-user
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## AF-149: Add a staging environment (separate namespace + branch-gated deploy)                                                                                                                                                               
                                                                                                                                                                                                                                             
  Isolated staging stack sharing the cluster with prod, in its own namespace with its own DB, hostnames, images, and secrets.                                                                                                                
                                                                                                                                                                                                                                             
 ### What this adds                                                                                                                                                                                                                             
                                                                                                                                                                                                                                             
  - Namespace isolation — staging in agent-farm-staging, prod stays in agent-farm. Service DNS is namespace-relative, so connection strings/secret names resolve per-namespace with no chart edits.                                          
  - Branch-gated deploys — deploy.yml picks env from github.ref_name: staging → staging config + -staging tags + STAGING_* secrets; main → prod; any other branch rejected.                                                                  
  - API workload isolation — new K8S_NAMESPACE env (from .Release.Namespace) so the pod spawns agents in its own namespace.                                                                                                                  
  - Helmfile parameterization — NAMESPACE env + qualified needs:; API/UI image.tag from env (empty = prod default).                                                                                                                          
  - Namespace-scoped deploy identity — litellm-key Job SA is configurable (LITELLM_KEY_SERVICE_ACCOUNT); staging uses its own SA, no cluster RBAC bootstrap. Adds k8s/agent-farm-user.staging.yaml (RBAC-only).                              
  - Separate images — all four images suffixed -staging; no :latest from staging.                                                                                                                                                            
  - Email disabled on staging (inverted main-only condition).                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                             
  ### GitHub config added for staging                                                                                                                                                                                                            
                                                                                                                                                                                                                                             
  - Variables (3): STAGING_API_HOST, STAGING_UI_HOST, STAGING_WEB_APP_URL                                                                                                                                                                    
  - Secrets (8): STAGING_POSTGRES_APP_PASSWORD, STAGING_POSTGRES_LITELLM_PASSWORD, STAGING_LITELLM_MASTER_KEY, STAGING_SECRET_SIGNING_KEY, STAGING_SUPER_USER_CREDENTIALS, STAGING_AGENT_TOKEN_ENCRYPTION_KEY, STAGING_KUBECONFIG_B64,       
  STAGING_POD_KUBECONFIG_B64                                                                                                                                                                                                                 
  - Prod secrets/vars (registry, OpenRouter, bastion, DB user/db names, storage, Google) reused as-is.                                                                                                                                       
                                                                                                                                                                                                                                             
  ### Out-of-band (not in this PR)                                                                                                                                                                                                               
                                                                                                                                                                                                                                             
  - staging branch + optional default-branch flip; agent-farm-staging namespace + SA/RBAC (already provisioned).                                                                                                                             
  - Docs: agent_plans/AF-149_plan.md, .env.deploy.spec guidance, .gitignore for .env.deploy.*.