### PR TITLE
Af 215 persist hermes agent workspace

### DIFF
--- a/api/domains/agents/builders/hermes.py
+++ b/api/domains/agents/builders/hermes.py
@@ -257,9 +257,16 @@ def build_hermes_deployment(
                                     name="data",
                                     mount_path="/opt/data",
                                 ),
+                                # /workspace is the agent's cwd; back it with the
+                                # per-agent PVC so agent-written files survive
+                                # restarts (AF-215) — like ocbw's persistent
+                                # ./agents/<name>/workspace and OpenClaw's
+                                # PVC-nested workspace. subPath keeps it a
+                                # sibling of the /opt/data content on one PVC.
                                 client.V1VolumeMount(
-                                    name="workspace",
+                                    name="data",
                                     mount_path="/workspace",
+                                    sub_path="workspace",
                                 ),
                             ],
                         )
@@ -274,10 +281,6 @@ def build_hermes_deployment(
                             persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
                                 claim_name=name
                             ),
-                        ),
-                        client.V1Volume(
-                            name="workspace",
-                            empty_dir=client.V1EmptyDirVolumeSource(),
                         ),
                     ],
                 ),

--- a/api/domains/agents/builders/hermes.py
+++ b/api/domains/agents/builders/hermes.py
@@ -243,6 +243,20 @@ def build_hermes_deployment(
                                 period_seconds=15,
                                 failure_threshold=6,
                             ),
+                            env=[
+                                # The hermes process starts in its install dir
+                                # (/opt/hermes) and the runtime user's HOME is
+                                # /opt/data (the state dir), so without these the
+                                # agent's shell is anchored in the wrong place and
+                                # relative writes miss the persistent /workspace.
+                                # ocbw sets both alongside terminal.cwd — mirror it.
+                                client.V1EnvVar(
+                                    name="TERMINAL_CWD", value="/workspace"
+                                ),
+                                client.V1EnvVar(
+                                    name="MESSAGING_CWD", value="/workspace"
+                                ),
+                            ],
                             env_from=[
                                 client.V1EnvFromSource(
                                     secret_ref=client.V1SecretEnvSource(name=name)

--- a/api/domains/agents/scripts/hermes/start.sh
+++ b/api/domains/agents/scripts/hermes/start.sh
@@ -35,6 +35,11 @@ if [ -f /app/config/aai-cli-setup.sh ]; then
   sh /app/config/aai-cli-setup.sh || echo "[aai-cli] setup failed; continuing"
 fi
 
+# /workspace persists across restarts (PVC). The personality files above are
+# overwritten from the configmap every boot, but skills are additive — prune
+# them so a skill from a removed integration can't linger from a previous boot.
+rm -rf /workspace/skills
+
 if [ -f /app/config/skills.json ]; then
   python3 - <<'PYEOF'
 import json, pathlib

--- a/api/tests/integration/test_agents.py
+++ b/api/tests/integration/test_agents.py
@@ -2200,20 +2200,20 @@ def test_start_hermes_agent_deployment_has_workspace_volume():
             assert_that(response.status_code, equal_to(status.HTTP_200_OK))
             deployment = k8s.create_deployment.call_args.args[1]
             mounts = {
-                m.mount_path
+                m.mount_path: m
                 for m in deployment.spec.template.spec.containers[0].volume_mounts
             }
             assert_that("/opt/data" in mounts, equal_to(True))
             assert_that("/workspace" in mounts, equal_to(True))
 
-        with then("one volume is emptyDir for workspace"):
-            from kubernetes.client import V1EmptyDirVolumeSource
-
+        with then("the workspace persists on the agent PVC, not an emptyDir"):
+            # AF-215: /workspace is a subPath of the per-agent PVC so files the
+            # agent writes to its cwd survive restarts.
+            assert_that(mounts["/workspace"].name, equal_to("data"))
+            assert_that(mounts["/workspace"].sub_path, equal_to("workspace"))
             volumes = deployment.spec.template.spec.volumes
-            empty_dirs = [
-                v for v in volumes if isinstance(v.empty_dir, V1EmptyDirVolumeSource)
-            ]
-            assert_that(len(empty_dirs), equal_to(1))
+            empty_dirs = [v for v in volumes if v.empty_dir is not None]
+            assert_that(len(empty_dirs), equal_to(0))
 
 
 def test_pair_hermes_agent_returns_400():

--- a/api/tests/unit/test_hermes_builders.py
+++ b/api/tests/unit/test_hermes_builders.py
@@ -350,6 +350,18 @@ def test_build_hermes_deployment_has_no_empty_dir_workspace_volume():
     assert_that("workspace" in volume_names, equal_to(False))
 
 
+def test_build_hermes_deployment_anchors_cwd_env_to_workspace():
+    # The hermes process starts in its install dir (/opt/hermes) and the user's
+    # HOME is /opt/data, so without these env vars the agent's shell is anchored
+    # in the wrong place and relative writes miss the persistent /workspace.
+    # ocbw sets both alongside terminal.cwd (openclaw_bootstrap/hermes.py) —
+    # mirror that.
+    dep = build_hermes_deployment(_AGENT_ID, _ORG_ID, _NS, "hermes:latest")
+    env = {e.name: e.value for e in dep.spec.template.spec.containers[0].env or []}
+    assert_that(env.get("TERMINAL_CWD"), equal_to("/workspace"))
+    assert_that(env.get("MESSAGING_CWD"), equal_to("/workspace"))
+
+
 def test_start_sh_prunes_stale_skills_before_seeding():
     # /workspace persists now, so a skill file from a removed integration would
     # linger without an explicit prune before re-seeding.

--- a/api/tests/unit/test_hermes_builders.py
+++ b/api/tests/unit/test_hermes_builders.py
@@ -321,17 +321,42 @@ def test_build_hermes_deployment_mounts_opt_data_and_workspace():
     assert_that("/workspace" in mounts, equal_to(True))
 
 
-def test_build_hermes_deployment_has_empty_dir_workspace():
-    from kubernetes.client import V1EmptyDirVolumeSource
-
+def test_build_hermes_deployment_workspace_is_pvc_backed():
+    # /workspace must persist across restarts (AF-215): it is a subPath of the
+    # per-agent PVC, not an ephemeral emptyDir — mirroring ocbw's persistent
+    # ./agents/<name>/workspace bind-mount and OpenClaw's PVC-nested workspace.
     dep = build_hermes_deployment(_AGENT_ID, _ORG_ID, _NS, "hermes:latest")
-    workspace_vols = [
-        v for v in dep.spec.template.spec.volumes if v.name == "workspace"
-    ]
-    assert_that(len(workspace_vols), equal_to(1))
-    assert_that(
-        isinstance(workspace_vols[0].empty_dir, V1EmptyDirVolumeSource), equal_to(True)
-    )
+    mounts = {
+        m.mount_path: m for m in dep.spec.template.spec.containers[0].volume_mounts
+    }
+    workspace = mounts["/workspace"]
+    assert_that(workspace.name, equal_to("data"))
+    assert_that(workspace.sub_path, equal_to("workspace"))
+
+
+def test_build_hermes_deployment_opt_data_stays_on_pvc_root():
+    dep = build_hermes_deployment(_AGENT_ID, _ORG_ID, _NS, "hermes:latest")
+    mounts = {
+        m.mount_path: m for m in dep.spec.template.spec.containers[0].volume_mounts
+    }
+    data = mounts["/opt/data"]
+    assert_that(data.name, equal_to("data"))
+    assert_that(data.sub_path, equal_to(None))
+
+
+def test_build_hermes_deployment_has_no_empty_dir_workspace_volume():
+    dep = build_hermes_deployment(_AGENT_ID, _ORG_ID, _NS, "hermes:latest")
+    volume_names = {v.name for v in dep.spec.template.spec.volumes}
+    assert_that("workspace" in volume_names, equal_to(False))
+
+
+def test_start_sh_prunes_stale_skills_before_seeding():
+    # /workspace persists now, so a skill file from a removed integration would
+    # linger without an explicit prune before re-seeding.
+    assert_that(HERMES_START_SH, contains_string("rm -rf /workspace/skills"))
+    prune_at = HERMES_START_SH.index("rm -rf /workspace/skills")
+    seed_at = HERMES_START_SH.index("skills.json")
+    assert_that(prune_at < seed_at, equal_to(True))
 
 
 def test_build_hermes_config_map_includes_aai_cli_kwargs_when_provided():

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
 version: 0.6.1
-appVersion: "0.29.0"
+appVersion: "0.30.0"


### PR DESCRIPTION
Back the Hermes agent's `/workspace` with its per-agent PVC and anchor the agent's shell there, so files it writes survive pod restarts instead of vanishing with an emptyDir.

## What's included

- **`api/domains/agents/builders/hermes.py`** — mount `/workspace` from the per-agent PVC via `subPath: workspace` (a sibling of the existing `/opt/data` content on the same claim), replacing the ephemeral `emptyDir`. Add `TERMINAL_CWD=/workspace` and `MESSAGING_CWD=/workspace` env vars so the agent's shell is anchored in the persistent workspace rather than its install dir (`/opt/hermes`) — mirrors ocbw.
- **`api/domains/agents/scripts/hermes/start.sh`** — prune stale `/workspace/skills` before re-seeding from `skills.json`, so a now-persistent workspace doesn't accumulate old skill copies.
- **`helm/agentfarm-api/Chart.yaml`** — bump `appVersion` to `0.30.0`.
- **Tests** — `test_hermes_builders.py` / `test_agents.py` assert the PVC-backed workspace (name `data`, `subPath: workspace`), no emptyDir workspace volume, `/opt/data` still on the PVC root, the skills prune, and the cwd env vars.