### PR TITLE
AF-203: stop agents advertising runtime chat commands

### DIFF
--- a/api/domains/agents/runtime_policy.py
+++ b/api/domains/agents/runtime_policy.py
@@ -1,0 +1,31 @@
+"""Runtime-behaviour policy blocks appended to every agent's AGENTS.md.
+
+Both Hermes and OpenClaw auto-load AGENTS.md into the startup system prompt, so this
+is where cross-cutting "how to behave in chat" rules belong. Unlike
+``build_integrations_policy_md``, these blocks are unconditional — they don't depend on
+which integrations an agent has.
+"""
+
+# Both runtimes expose gateway-level chat commands (Hermes: /help, /whoami, /new,
+# /reset, /model, ...; OpenClaw: /help, /commands, /status, /clear, /model, ...) and
+# both strip them before the model sees the message. Agents nonetheless learn the
+# commands from the runtime's own system prompt and volunteer them in greetings —
+# advertising an interface they don't implement, and on Hermes often naming commands
+# the reader isn't permitted to run (non-admins get only the /help + /whoami floor
+# plus user_allowed_commands). Kept runtime-neutral: one block ships to both.
+_CHAT_COMMANDS_POLICY_MD = """
+## Chat Commands
+
+Never mention, list, or explain platform chat commands — anything a user types
+starting with `/` (`/help`, `/new`, `/clear`, `/reset`, `/model`, `/status`, ...).
+
+- Don't offer them in greetings, onboarding, or "here's what I can do" summaries.
+- Describe what you can do in plain language instead.
+- If someone asks how to control the session, say it's a platform feature handled by
+  their workspace admin — don't name specific commands.
+"""
+
+
+def build_chat_commands_policy_md() -> str:
+    """Render the block that stops agents advertising gateway chat commands."""
+    return _CHAT_COMMANDS_POLICY_MD

--- a/api/domains/agents/service.py
+++ b/api/domains/agents/service.py
@@ -22,6 +22,7 @@ from api.domains.agents.aai_cli_artifacts import (
     provider_secrets_map,
 )
 from api.domains.agents.aai_cli_skills import build_skills_manifest_from_zips
+from api.domains.agents.runtime_policy import build_chat_commands_policy_md
 from api.domains.skills.models import Skill
 from api.domains.skills.repository import SkillRepository
 from api.domains.agents.builders import (
@@ -1039,7 +1040,13 @@ class AgentService:
         )
         # AGENTS.md is auto-loaded into the startup prompt by both runtimes, so the
         # --profile mapping + no-fallback policy is appended here (not just to TOOLS.md).
-        agents_md = rendered.agents_md + build_integrations_policy_md(decrypted)
+        # The chat-commands policy rides along unconditionally — it applies to every
+        # agent, integrations or not, and to custom templates we don't control.
+        agents_md = (
+            rendered.agents_md
+            + build_integrations_policy_md(decrypted)
+            + build_chat_commands_policy_md()
+        )
 
         if agent.agent_type == AgentType.HERMES:
             assert hermes_cfg is not None

--- a/api/tests/integration/test_agents.py
+++ b/api/tests/integration/test_agents.py
@@ -2836,7 +2836,45 @@ def test_start_agent_injects_profile_mapping_into_agents_md_hermes():
             assert_that(agents_md, contains_string("./skills/aai-cli/"))
 
 
-def test_start_agent_no_integrations_leaves_agents_md_unmodified():
+def test_start_agent_injects_chat_commands_policy_into_agents_md_openclaw():
+    with given([*_GIVEN, there_is_an_agent()]) as context:
+        client: TestClient = context.client
+        k8s: KubernetesClient = context.injector.get(KubernetesClient)
+
+        with when("the OpenClaw agent starts"):
+            response = client.post(
+                f"{_BASE}/{context.agent.id}/start", headers=_auth(context)
+            )
+
+        with then("AGENTS.md tells the agent not to advertise chat commands"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            config_map = k8s.create_config_map.call_args.args[1]
+            agents_md = config_map.data["AGENTS.md"]
+            assert_that(agents_md, contains_string("## Chat Commands"))
+            assert_that(agents_md, contains_string("/help"))
+
+
+def test_start_agent_injects_chat_commands_policy_into_agents_md_hermes():
+    with given(
+        [*_GIVEN_WITH_HERMES_IMAGE, there_is_an_agent(agent_type=AgentType.HERMES)]
+    ) as context:
+        client: TestClient = context.client
+        k8s: KubernetesClient = context.injector.get(KubernetesClient)
+
+        with when("the Hermes agent starts"):
+            response = client.post(
+                f"{_BASE}/{context.agent.id}/start", headers=_auth(context)
+            )
+
+        with then("AGENTS.md tells the agent not to advertise chat commands"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            config_map = k8s.create_config_map.call_args.args[1]
+            agents_md = config_map.data["AGENTS.md"]
+            assert_that(agents_md, contains_string("## Chat Commands"))
+            assert_that(agents_md, contains_string("/help"))
+
+
+def test_start_agent_no_integrations_omits_integrations_block():
     with given([*_GIVEN, there_is_an_agent()]) as context:
         client: TestClient = context.client
         k8s: KubernetesClient = context.injector.get(KubernetesClient)

--- a/api/tests/unit/test_runtime_policy.py
+++ b/api/tests/unit/test_runtime_policy.py
@@ -1,0 +1,33 @@
+from api.domains.agents.runtime_policy import build_chat_commands_policy_md
+
+# --- build_chat_commands_policy_md --------------------------------------------
+
+
+def test_chat_commands_policy_md_is_always_emitted():
+    # Unlike the integrations block, this policy has no precondition — an agent
+    # with zero integrations still greets people and still must not advertise
+    # commands it neither owns nor receives.
+    md = build_chat_commands_policy_md()
+    assert md.strip() != ""
+    assert "## Chat Commands" in md
+
+
+def test_chat_commands_policy_md_forbids_advertising_commands():
+    md = build_chat_commands_policy_md()
+    assert "/help" in md
+    # The greeting is where this actually leaks, so it must be called out.
+    assert "greeting" in md.lower()
+
+
+def test_chat_commands_policy_md_is_runtime_neutral():
+    # The same block ships to Hermes and OpenClaw agents; naming one runtime
+    # would be wrong for the other.
+    md = build_chat_commands_policy_md()
+    assert "Hermes" not in md
+    assert "OpenClaw" not in md
+
+
+def test_chat_commands_policy_md_does_not_mention_profiles():
+    # Guards the "no integrations configured" contract: AGENTS.md must stay free
+    # of any `--profile` mapping when no secrets are set.
+    assert "--profile" not in build_chat_commands_policy_md()

--- a/helm/agentfarm-api/Chart.yaml
+++ b/helm/agentfarm-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: agentfarm-api
 description: FastAPI backend for agent-farm
 version: 0.6.1
-appVersion: "0.30.0"
+appVersion: "0.30.1"


### PR DESCRIPTION
Agents were greeting users with things like "send `/help` to see available commands". Those commands belong to the messaging gateway, not the agent, so this adds an unconditional `AGENTS.md` policy block telling agents never to mention them.

## What's included

- **`api/domains/agents/runtime_policy.py`** (new) — `build_chat_commands_policy_md()` returns a short, runtime-neutral `## Chat Commands` block: never mention, list, or explain `/`-prefixed platform commands; don't offer them in greetings or "here's what I can do" summaries; describe capabilities in plain language; defer command questions to the workspace admin.
- **`api/domains/agents/service.py`** — appends the block in `start_agent`, alongside the existing integrations block. Unconditional, unlike `build_integrations_policy_md`, which returns `""` when no integrations are configured.
- **`api/tests/unit/test_runtime_policy.py`** (new) — covers always-emitted, forbids-advertising, runtime-neutral, and no `--profile` leakage.
- **`api/tests/integration/test_agents.py`** — asserts the block reaches `AGENTS.md` for both Hermes and OpenClaw. Also fixes `test_start_agent_no_integrations_leaves_agents_md_unmodified`, which referenced an unassigned `config_map` (it would have raised `NameError`); renamed to `..._omits_integrations_block`, since `AGENTS.md` is no longer unmodified.
- **`helm/agentfarm-api/Chart.yaml`** — `appVersion` `0.30.0` → `0.30.1`. No chart files changed, so `version` stays `0.6.1`.

No template files were touched. None of the six predefined templates ever mentioned `/help` — agents pick the commands up from the runtime's own system prompt — so the fix belongs at the injection point, not in template text. Putting it in `start_agent` covers all predefined and custom templates, needs no template reseed, and reaches existing agents on their next restart.

## Required repo config

None.

## Notes

- Existing agents only pick this up when restarted; `agents_md` is rebuilt per start, so running pods are unaffected until then.
- Both runtimes gate these commands at the gateway (Hermes registers them as native Slack slash commands and gates them per user; OpenClaw strips them before the model sees the message), so an agent describing them is describing an interface it doesn't implement.

## Testing

- `make check-api` — ruff + format clean; `ty` reports only the 2 pre-existing `sa.dialects` warnings in `migrations/versions/ab2b4bb88c6f_…py`.
- Full API suite: 761 passed.

