### PR TITLE
AF-230-untagged-agents-ignore-messages

### DIFF
--- a/api/domains/agents/builders/hermes.py
+++ b/api/domains/agents/builders/hermes.py
@@ -112,7 +112,7 @@ def build_hermes_config(
         "reply_in_thread": True,
         "broadcast_reply": False,
         "require_mention": True,
-        "strict_mention": False,
+        "strict_mention": True,
         "unauthorized_dm_behavior": "ignore",
     }
     return cfg
@@ -130,7 +130,7 @@ def build_hermes_config_telegram(
         enabled_plugins.append("telegram-channel-allowlist")
     if dm_policy != "open":
         enabled_plugins.append("telegram-deny-dms")
-    return _hermes_config_core(
+    cfg = _hermes_config_core(
         model,
         litellm_base_url,
         enabled_plugins,
@@ -141,6 +141,11 @@ def build_hermes_config_telegram(
         },
         approval_mode=approval_mode,
     )
+    cfg["telegram"] = {
+        "require_mention": True,
+        "exclusive_bot_mentions": True,
+    }
+    return cfg
 
 
 def build_hermes_config_map(

--- a/api/domains/agents/builders/openclaw.py
+++ b/api/domains/agents/builders/openclaw.py
@@ -152,6 +152,7 @@ def build_openclaw_config_overlay_teams(
                 "dmPolicy": "open",
                 "allowFrom": ["*"],
                 "groupPolicy": "open",
+                "requireMention": True,
                 "streaming": {"mode": "off"},
                 "webhook": {"port": 3978, "path": "/api/messages"},
             }
@@ -188,10 +189,10 @@ def build_openclaw_config_overlay_telegram(
                 "groupPolicy": group_policy,
                 "dmPolicy": openclaw_dm_policy,
                 "allowFrom": allow_from,
-                **(
-                    {"groups": {cid: {"requireMention": True} for cid in (allowed_chat_ids or [])}}
+                "groups": (
+                    {cid: {"requireMention": True} for cid in (allowed_chat_ids or [])}
                     if group_policy == "allowlist"
-                    else {}
+                    else {"*": {"requireMention": True}}
                 ),
             }
         },

--- a/api/domains/agents/builders/openclaw.py
+++ b/api/domains/agents/builders/openclaw.py
@@ -120,6 +120,8 @@ def build_openclaw_config_overlay(
                 "groupPolicy": slack_group_policy,
                 "dmPolicy": openclaw_dm_policy,
                 "allowFrom": allow_from,
+                "requireMention": True,
+                "thread": {"requireExplicitMention": True},
                 "replyToModeByChatType": {
                     "direct": direct_reply_mode,
                     "group": "all",
@@ -186,7 +188,11 @@ def build_openclaw_config_overlay_telegram(
                 "groupPolicy": group_policy,
                 "dmPolicy": openclaw_dm_policy,
                 "allowFrom": allow_from,
-                **({"groups": {cid: {} for cid in (allowed_chat_ids or [])}} if group_policy == "allowlist" else {}),
+                **(
+                    {"groups": {cid: {"requireMention": True} for cid in (allowed_chat_ids or [])}}
+                    if group_policy == "allowlist"
+                    else {}
+                ),
             }
         },
     )

--- a/api/tests/integration/test_agents.py
+++ b/api/tests/integration/test_agents.py
@@ -1637,6 +1637,8 @@ def test_start_agent_overlay_uses_slack_settings():
                 slack["channels"],
                 equal_to({"C123": {"enabled": True, "requireMention": True}}),
             )
+            assert_that(slack["requireMention"], equal_to(True))
+            assert_that(slack["thread"]["requireExplicitMention"], equal_to(True))
 
 
 def test_start_agent_open_policy_sets_allow_from_wildcard():

--- a/api/tests/unit/test_hermes_builders.py
+++ b/api/tests/unit/test_hermes_builders.py
@@ -34,6 +34,16 @@ def test_build_hermes_config_unauthorized_dm_behavior_is_ignore():
     assert_that(cfg["slack"]["unauthorized_dm_behavior"], equal_to("ignore"))
 
 
+def test_build_hermes_config_strict_mention_is_enabled():
+    cfg = build_hermes_config("litellm/qwen3", "http://litellm:4000")
+    assert_that(cfg["slack"]["strict_mention"], equal_to(True))
+
+
+def test_build_hermes_config_require_mention_is_enabled():
+    cfg = build_hermes_config("litellm/qwen3", "http://litellm:4000")
+    assert_that(cfg["slack"]["require_mention"], equal_to(True))
+
+
 def test_build_hermes_config_plugins_has_deny_dms():
     cfg = build_hermes_config("litellm/qwen3", "http://litellm:4000")
     assert_that("slack-deny-dms" in cfg["plugins"]["enabled"], equal_to(True))
@@ -469,6 +479,16 @@ def test_build_hermes_config_telegram_sets_model():
 def test_build_hermes_config_telegram_has_no_slack_section():
     cfg = build_hermes_config_telegram("litellm/qwen3", "http://litellm:4000")
     assert_that(cfg, is_not(has_key("slack")))
+
+
+def test_build_hermes_config_telegram_require_mention_is_enabled():
+    cfg = build_hermes_config_telegram("litellm/qwen3", "http://litellm:4000")
+    assert_that(cfg["telegram"]["require_mention"], equal_to(True))
+
+
+def test_build_hermes_config_telegram_exclusive_bot_mentions_is_enabled():
+    cfg = build_hermes_config_telegram("litellm/qwen3", "http://litellm:4000")
+    assert_that(cfg["telegram"]["exclusive_bot_mentions"], equal_to(True))
 
 
 def test_build_hermes_config_telegram_has_telegram_platform():

--- a/api/tests/unit/test_openclaw_builders.py
+++ b/api/tests/unit/test_openclaw_builders.py
@@ -39,6 +39,25 @@ def test_build_openclaw_config_overlay_teams_gateway_auth_is_none():
     assert_that(overlay["gateway"]["auth"]["mode"], equal_to("none"))
 
 
+def test_build_openclaw_config_overlay_thread_requires_explicit_mention():
+    overlay = build_openclaw_config_overlay("litellm/gpt-4o", "http://litellm:4000")
+    assert_that(overlay["channels"]["slack"]["thread"]["requireExplicitMention"], equal_to(True))
+
+
+def test_build_openclaw_config_overlay_require_mention_is_enabled():
+    overlay = build_openclaw_config_overlay("litellm/gpt-4o", "http://litellm:4000")
+    assert_that(overlay["channels"]["slack"]["requireMention"], equal_to(True))
+
+
+def test_build_openclaw_config_overlay_allowlisted_channel_requires_mention():
+    overlay = build_openclaw_config_overlay(
+        "litellm/gpt-4o",
+        "http://litellm:4000",
+        slack_channel_ids=["C001"],
+    )
+    assert_that(overlay["channels"]["slack"]["channels"]["C001"]["requireMention"], equal_to(True))
+
+
 def test_build_deployment_has_pvc_owner_init_container():
     dep = build_deployment(
         agent_id=UUID("00000000-0000-0000-0000-000000000001"),
@@ -147,7 +166,7 @@ def test_build_openclaw_config_overlay_telegram_allowed_chat_ids():
     )
     assert_that(
         overlay["channels"]["telegram"]["groups"],
-        equal_to({"-100123": {}, "-100456": {}}),
+        equal_to({"-100123": {"requireMention": True}, "-100456": {"requireMention": True}}),
     )
 
 

--- a/api/tests/unit/test_openclaw_builders.py
+++ b/api/tests/unit/test_openclaw_builders.py
@@ -34,6 +34,11 @@ def test_build_openclaw_config_overlay_gateway_auth_is_none():
     assert_that(overlay["gateway"]["auth"]["mode"], equal_to("none"))
 
 
+def test_build_openclaw_config_overlay_teams_require_mention_is_enabled():
+    overlay = build_openclaw_config_overlay_teams("litellm/gpt-4o", "http://litellm:4000")
+    assert_that(overlay["channels"]["msteams"]["requireMention"], equal_to(True))
+
+
 def test_build_openclaw_config_overlay_teams_gateway_auth_is_none():
     overlay = build_openclaw_config_overlay_teams("litellm/gpt-4o", "http://litellm:4000")
     assert_that(overlay["gateway"]["auth"]["mode"], equal_to("none"))
@@ -175,9 +180,12 @@ def test_build_openclaw_config_overlay_telegram_allowed_chat_ids_empty_when_none
     assert_that(overlay["channels"]["telegram"]["groups"], equal_to({}))
 
 
-def test_build_openclaw_config_overlay_telegram_no_allowed_chats_when_open():
+def test_build_openclaw_config_overlay_telegram_open_policy_gates_all_groups():
     overlay = build_openclaw_config_overlay_telegram("litellm/gpt-4o", "http://litellm:4000", group_policy="open")
-    assert_that("groups" in overlay["channels"]["telegram"], equal_to(False))
+    assert_that(
+        overlay["channels"]["telegram"]["groups"],
+        equal_to({"*": {"requireMention": True}}),
+    )
 
 
 # --- Telegram secret --------------------------------------------------------

--- a/docs/architecture/runtime-and-deployment.md
+++ b/docs/architecture/runtime-and-deployment.md
@@ -40,9 +40,12 @@ Builders set this per runtime and platform:
 | Hermes   | Slack    | `slack.require_mention` and `slack.strict_mention`                                              |
 | Hermes   | Telegram | `telegram.require_mention` and `telegram.exclusive_bot_mentions`                                |
 | OpenClaw | Slack    | `channels.slack.requireMention`, `channels.slack.thread.requireExplicitMention`, and per-channel `requireMention` |
-| OpenClaw | Telegram | per-group `channels.telegram.groups.<chat_id>.requireMention`                                   |
+| OpenClaw | Teams    | `channels.msteams.requireMention`                                                               |
+| OpenClaw | Telegram | `channels.telegram.groups.<chat_id>.requireMention`, or the `*` wildcard group when the group policy is open |
 
-Two residual gaps are runtime limitations rather than configuration choices. Hermes Telegram treats a direct reply to the agent's own message as a trigger and exposes no switch to disable it; OpenClaw Telegram behaves the same way. Both remain addressed to a single agent, so neither reopens the cross-agent case. OpenClaw Telegram also emits no `groups` map when the group policy is open, leaving gating to the runtime default.
+The table covers all five supported runtime/platform pairs. Every value is pinned explicitly rather than left to a runtime default, so an upstream default change cannot silently reopen the gap.
+
+Guarantee strength differs by platform. Slack on both runtimes enforces a fresh mention per message, disabling thread auto-engagement. Teams and Telegram enforce "mention required" but expose no per-message re-mention control, so a direct reply to the agent's own message still reaches it. Those replies remain addressed to exactly one agent, so they do not reopen the cross-agent case.
 
 Runtime configuration is generated at agent start, so a running agent keeps the gating it was started with until it is stopped and started again.
 

--- a/docs/architecture/runtime-and-deployment.md
+++ b/docs/architecture/runtime-and-deployment.md
@@ -29,6 +29,23 @@ A failed Slack or Telegram credential check or Kubernetes start can place the ag
 
 Runtime is persisted as `agent_type`; platform is persisted separately. Both runtimes receive rendered template files, skills, integrations, model/LiteLLM settings, and ingest credentials, but their filesystem and configuration shapes differ.
 
+## Mention gating
+
+In a shared channel or group an agent responds only to messages that explicitly mention it. Every agent owns its own bot identity and therefore receives every message in rooms it belongs to, so mention gating is the only thing that keeps an untagged agent from acting on a message addressed to another agent. Gating requires a fresh mention per message: participating earlier in a thread does not entitle an agent to later messages. Direct messages are exempt.
+
+Builders set this per runtime and platform:
+
+| Runtime  | Platform | Generated configuration                                                                       |
+| -------- | -------- | --------------------------------------------------------------------------------------------- |
+| Hermes   | Slack    | `slack.require_mention` and `slack.strict_mention`                                              |
+| Hermes   | Telegram | `telegram.require_mention` and `telegram.exclusive_bot_mentions`                                |
+| OpenClaw | Slack    | `channels.slack.requireMention`, `channels.slack.thread.requireExplicitMention`, and per-channel `requireMention` |
+| OpenClaw | Telegram | per-group `channels.telegram.groups.<chat_id>.requireMention`                                   |
+
+Two residual gaps are runtime limitations rather than configuration choices. Hermes Telegram treats a direct reply to the agent's own message as a trigger and exposes no switch to disable it; OpenClaw Telegram behaves the same way. Both remain addressed to a single agent, so neither reopens the cross-agent case. OpenClaw Telegram also emits no `groups` map when the group policy is open, leaving gating to the runtime default.
+
+Runtime configuration is generated at agent start, so a running agent keeps the gating it was started with until it is stopped and started again.
+
 ## Telemetry and costs
 
 Agent runtimes report messages and tool-call state to the separate Ingest API using the per-start ingest key. Ingest authentication currently remains valid after stop because status is not checked and the stored key is not cleared. Costs follow a separate path: the API queries LiteLLM and attributes spend through each agent's LiteLLM key identity.

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -21,6 +21,7 @@ An Agent is the central operational aggregate. It connects organization tenancy,
 - Runtime and platform are separate. Hermes supports Slack and Telegram; OpenClaw supports Slack, Teams, and Telegram.
 - Persisted lifecycle states are `STOPPED`, `RUNNING`, and `ERROR`.
 - Slack agents require bot and app tokens. Teams agents require app ID, app password, and tenant ID. Telegram agents require a bot token.
+- Slack and Telegram agents respond in shared channels and groups only to messages that explicitly mention them, and require that mention on every message rather than inheriting it from earlier thread participation. Direct messages are exempt. Gating is generated at start; see [`../architecture/runtime-and-deployment.md`](../architecture/runtime-and-deployment.md).
 - Each active Slack agent must use a distinct bot token (enforced globally); creating or updating with a duplicate returns 409. Deleting an agent releases its token for reuse.
 - Platform is not changed through agent update. Runtime/platform compatibility is schema-validated.
 - Running agents reject configuration updates.

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -21,7 +21,7 @@ An Agent is the central operational aggregate. It connects organization tenancy,
 - Runtime and platform are separate. Hermes supports Slack and Telegram; OpenClaw supports Slack, Teams, and Telegram.
 - Persisted lifecycle states are `STOPPED`, `RUNNING`, and `ERROR`.
 - Slack agents require bot and app tokens. Teams agents require app ID, app password, and tenant ID. Telegram agents require a bot token.
-- Slack and Telegram agents respond in shared channels and groups only to messages that explicitly mention them, and require that mention on every message rather than inheriting it from earlier thread participation. Direct messages are exempt. Gating is generated at start; see [`../architecture/runtime-and-deployment.md`](../architecture/runtime-and-deployment.md).
+- Agents respond in shared channels and groups only to messages that explicitly mention them, on every supported platform. Slack additionally requires that mention on every message rather than inheriting it from earlier thread participation; Teams and Telegram expose no equivalent control. Direct messages are exempt. Gating is generated at start; see [`../architecture/runtime-and-deployment.md`](../architecture/runtime-and-deployment.md).
 - Each active Slack agent must use a distinct bot token (enforced globally); creating or updating with a duplicate returns 409. Deleting an agent releases its token for reuse.
 - Platform is not changed through agent update. Runtime/platform compatibility is schema-validated.
 - Running agents reject configuration updates.


### PR DESCRIPTION
added requireMention to both runtimes and explicitMention in thread for both runtimes. Now agents require explicit mention even in the thread in order to reply