### PR TITLE
Tell agents what each integration can do, not just its --profile

### DIFF
--- a/api/domains/agents/aai_cli_artifacts.py
+++ b/api/domains/agents/aai_cli_artifacts.py
@@ -264,12 +264,13 @@ _PROFILE_BUILDERS: dict[SecretProvider, Callable[..., str]] = {
 }
 
 
-_TOOL_CONTEXT_PROVIDERS = {
-    SecretProvider.GITHUB,
-    SecretProvider.JIRA,
-    SecretProvider.CONFLUENCE,
-    SecretProvider.BITBUCKET,
-}
+# Every provider reachable through an aai-cli --profile gets a "Configured Integrations"
+# line. This was previously limited to the four repo/issue trackers, which left Slack,
+# Gmail, Zoho Mail, Pipedrive, and the calendars with no "credentials are already in
+# place" note at all — so those agents would tell the user they had no access, or ask for
+# a token that was already mounted. Keyed off PROFILE_SLUGS so a new provider is covered
+# the moment it gets a profile.
+_TOOL_CONTEXT_PROVIDERS = frozenset(PROFILE_SLUGS)
 
 
 def build_tool_context_md(decrypted: Mapping[SecretProvider, SecretContent]) -> str:
@@ -291,7 +292,7 @@ def build_tool_context_md(decrypted: Mapping[SecretProvider, SecretContent]) -> 
     ]
     for provider in SecretProvider:
         content = decrypted.get(provider)
-        if content is None:
+        if content is None or provider not in PROFILE_SLUGS:
             continue
         if isinstance(content, GithubContent):
             base = PROFILE_SLUGS[SecretProvider.GITHUB]
@@ -323,6 +324,11 @@ def build_tool_context_md(decrypted: Mapping[SecretProvider, SecretContent]) -> 
                     f"- **Bitbucket** (`{base}`): workspace `{content.workspace}` "
                     f"({content.email}) — no repository configured; pass --repo explicitly"
                 )
+        else:
+            # Providers with no site/repo metadata worth printing still belong here: the
+            # point of this block is "credentials are already in place", which is exactly
+            # what a Slack- or Gmail-only agent was missing.
+            lines.append(f"- **{_INTEGRATION_LABELS[provider]}** (`{PROFILE_SLUGS[provider]}`)")
     return "\n".join(lines) + "\n"
 
 
@@ -400,6 +406,28 @@ _INTEGRATION_LABELS: dict[SecretProvider, str] = {
     SecretProvider.PIPEDRIVE: "Pipedrive",
 }
 
+# One-clause summary of what each integration can actually do, appended to its agents_md
+# line. Without it the always-loaded context named a --profile slug and nothing else, so
+# an agent asked "are there files in this channel?" had no token in context linking the
+# question to `slack-work` and would answer that it had no access — the profile slug alone
+# never told it what the profile was *for*. Sourced from the command surface documented in
+# each ``aai_cli_skills/<provider>.py``; keep in sync when commands are added. Providers
+# with no aai-cli skill doc (the calendars) are omitted and render as before.
+_INTEGRATION_CAPABILITIES: dict[SecretProvider, str] = {
+    SecretProvider.GITHUB: "PRs (diff, files, reviews, comments), issues, branches, repo source, Actions runs",
+    SecretProvider.JIRA: "issues (comments, attachments), sprints, boards, projects, users",
+    SecretProvider.CONFLUENCE: "pages (comments, attachments), spaces",
+    SecretProvider.BITBUCKET: "PRs (diff, comments), commits, branches, repo source, pipelines",
+    SecretProvider.GMAIL: "read and search mail (read-only)",
+    SecretProvider.GOOGLE_SHEETS: "list and read spreadsheets, read/update/clear cell ranges",
+    SecretProvider.ZOHO_MAIL: "read and search mail (read-only)",
+    SecretProvider.SLACK: (
+        "read channel data: list channels, list and download files and attachments, "
+        "read bookmarks, links, canvases (read-only)"
+    ),
+    SecretProvider.PIPEDRIVE: "deals, leads, persons, organizations, activities, notes, mailbox",
+}
+
 
 def _repo_scoped_profile_line(label: str, base: str, scope: str, scope_kind: str, repos: list[str]) -> str:
     """Render the agents_md line for a repo-scoped provider (GitHub/Bitbucket).
@@ -430,7 +458,9 @@ def build_integrations_policy_md(
     line, the nested command grammar with one worked example (agents otherwise burn
     turns guessing subcommands), one line per configured provider (GitHub/Bitbucket map
     each --profile slug to the repo it targets, or say to pass ``--repo`` when the
-    profile has none), and a read-the-file pointer to the on-demand skill docs. Full command
+    profile has none) closing with a one-clause summary of what that integration can do —
+    a bare slug left agents unable to connect a user's question to the profile that
+    answers it — and a read-the-file pointer to the on-demand skill docs. Full command
     syntax stays in the per-service
     ``./skills/aai-cli/<service>_skill.md`` files and TOOLS.md. Returns "" when no
     integrations are configured.
@@ -458,11 +488,13 @@ def build_integrations_policy_md(
             continue
         base = PROFILE_SLUGS[provider]
         if isinstance(content, GithubContent):
-            lines.append(_repo_scoped_profile_line("GitHub", base, content.owner, "owner", content.repos))
+            line = _repo_scoped_profile_line("GitHub", base, content.owner, "owner", content.repos)
         elif isinstance(content, BitbucketContent):
-            lines.append(_repo_scoped_profile_line("Bitbucket", base, content.workspace, "workspace", content.repos))
+            line = _repo_scoped_profile_line("Bitbucket", base, content.workspace, "workspace", content.repos)
         else:
-            lines.append(f"- **{_INTEGRATION_LABELS[provider]}**: `--profile {base}`")
+            line = f"- **{_INTEGRATION_LABELS[provider]}**: `--profile {base}`"
+        capability = _INTEGRATION_CAPABILITIES.get(provider)
+        lines.append(f"{line} — {capability}" if capability else line)
     return "\n".join(lines) + "\n"
 
 

--- a/api/tests/unit/test_aai_cli_artifacts.py
+++ b/api/tests/unit/test_aai_cli_artifacts.py
@@ -431,28 +431,28 @@ def test_tool_context_md_lists_bitbucket_profile():
     assert "my-workspace/my-repo" in md
 
 
-def test_tool_context_md_omits_non_aai_cli_providers():
+def test_tool_context_md_lists_providers_without_metadata():
+    # Providers with no per-secret metadata worth printing (no site URL, no
+    # owner/workspace) are still listed. The block's job is "credentials are already in
+    # place", and that matters most for exactly these: a Gmail- or Slack-only agent used
+    # to get no block at all and would tell the user it had no access.
     md = build_tool_context_md({SecretProvider.GMAIL: _GMAIL})
-    assert md == ""
+    assert "- **Gmail** (`gmail-work`)" in md
 
 
 def test_tool_context_md_empty_when_only_firecrawl():
+    # Firecrawl has no aai-cli profile, so it is not an "integration" in this sense.
     md = build_tool_context_md({SecretProvider.FIRECRAWL: FirecrawlContent(api_key="fc-x")})
     assert md == ""
 
 
-def test_tool_context_md_omits_slack():
-    # Slack has no per-secret metadata worth surfacing (unlike site URL/owner for
-    # Jira/GitHub/etc.) — deliberately excluded from _TOOL_CONTEXT_PROVIDERS, same as
-    # Gmail/Zoho Mail.
-    assert build_tool_context_md({SecretProvider.SLACK: _SLACK}) == ""
+def test_tool_context_md_lists_slack():
+    assert "- **Slack** (`slack-work`)" in build_tool_context_md({SecretProvider.SLACK: _SLACK})
 
 
-def test_tool_context_md_empty_when_only_pipedrive():
-    # Pipedrive is deliberately excluded from _TOOL_CONTEXT_PROVIDERS — no per-secret
-    # metadata (site URL, owner/workspace) worth surfacing beyond "configured".
+def test_tool_context_md_lists_pipedrive():
     md = build_tool_context_md({SecretProvider.PIPEDRIVE: _PIPEDRIVE})
-    assert md == ""
+    assert "- **Pipedrive** (`pipedrive-work`)" in md
 
 
 def test_tool_context_md_never_leaks_tokens():
@@ -511,6 +511,40 @@ def test_integrations_policy_md_includes_nested_command_grammar():
 def test_integrations_policy_md_emits_profile_line_per_provider():
     md = build_integrations_policy_md({SecretProvider.JIRA: _JIRA})
     assert "--profile jira-work" in md
+
+
+def test_integrations_policy_md_states_what_slack_can_do():
+    # A bare `--profile slack-work` gave the agent nothing to match a user's question
+    # against, so it would deny having Slack access while holding a working profile.
+    # The line has to name the capability, not just the slug.
+    md = build_integrations_policy_md({SecretProvider.SLACK: _SLACK})
+    assert "--profile slack-work" in md
+    assert "files" in md
+    assert "canvases" in md
+    assert "read-only" in md
+
+
+def test_integrations_policy_md_appends_capability_to_repo_scoped_line():
+    # The GitHub/Bitbucket lines are built by a different branch than the rest; the
+    # capability has to survive that path too, without losing the repo mapping.
+    github = validate_content(
+        SecretProvider.GITHUB,
+        {"token": "ghp_tok", "owner": "acme", "org": "acme", "repos": ["web"]},
+    )
+    md = build_integrations_policy_md({SecretProvider.GITHUB: github})
+    assert "`--profile github-work` → acme/web" in md
+    assert "Actions runs" in md
+
+
+def test_integrations_policy_md_omits_capability_for_providers_without_one():
+    # Calendars ship no aai-cli skill doc, so there is no verified command surface to
+    # describe — the line renders exactly as before rather than inventing one.
+    calendar = validate_content(
+        SecretProvider.GOOGLE_CALENDAR,
+        {"calendar_id": "primary", "access_token": "ya29.tok"},
+    )
+    md = build_integrations_policy_md({SecretProvider.GOOGLE_CALENDAR: calendar})
+    assert "- **Google Calendar**: `--profile google-calendar-work`\n" in md
 
 
 def test_integrations_policy_md_github_multi_repo_lists_all_profiles():


### PR DESCRIPTION
## Summary

Follow-up to #109. Slack channel data access works, but agents didn't reliably know they had it — an agent with the Slack skill attached told a user *"I can't search channel history, browse past messages, or look up attachments. This is a limitation of how I'm set up in Slack"*, then answered the same question correctly four minutes later with a full file listing. Same agent, same channel, opposite answers.

Neither failure was a credential or capability gap. Both are gaps in the context that is **always** loaded, and both are provider-agnostic — Slack just surfaced them first, because it's the one integration that collides with the agent's own transport.

## What changed

**`build_integrations_policy_md` (AGENTS.md) — state the capability, not just the slug.**

A Slack-only agent's entire integrations footprint was:

```
- **Slack**: `--profile slack-work`
```

Nothing there connects *"are there files attached in this channel?"* to `slack-work`. With no token in context matching the question, the model falls back on its prior about what a Slack bot can do. Each line now closes with a one-clause summary of the command surface:

```
- **Slack**: `--profile slack-work` — read channel data: list channels, list and
  download files and attachments, read bookmarks, links, canvases (read-only)
- **GitHub**: `--profile github-work` → aai-labs/agent-farm — PRs (diff, files,
  reviews, comments), issues, branches, repo source, Actions runs
```

Each blurb is taken from the commands actually documented in that provider's `aai_cli_skills/<provider>.py`, not written from memory. The calendars ship no aai-cli skill doc, so they get no blurb rather than an invented one, and render exactly as before.

**`_TOOL_CONTEXT_PROVIDERS` (TOOLS.md) — stop skipping most providers.**

The "Configured Integrations" block — the one that says *credentials are already in place, do not ask the user to re-provide them* — was gated on a hardcoded `{GITHUB, JIRA, CONFLUENCE, BITBUCKET}`. Slack, Gmail, Zoho Mail, Pipedrive and the calendars produced **no block at all**, which is why both failure transcripts end with the agent asking the user to share the file directly.

It's now keyed off `PROFILE_SLUGS`, so any provider reachable through a `--profile` is covered the moment it gets one. Providers with no site/repo metadata worth printing render as a plain `- **Slack** (`slack-work`)` line — "configured" is the whole point. Firecrawl has no profile and is still correctly excluded.

## Tests

Three tests asserted the old omissions (`test_tool_context_md_omits_slack`, `..._empty_when_only_pipedrive`, `..._omits_non_aai_cli_providers`) and are updated to the new behaviour with the reasoning recorded. Four new tests cover the capability blurbs, including the repo-scoped GitHub/Bitbucket branch (built by a different code path) and the deliberate no-blurb case.

`check-api`, `check-ui`, `check-migrations` clean. Full unit suite: 655 passed. Integration tests untouched by these strings — no test outside `test_aai_cli_artifacts.py` references either block.

## What this does *not* fix

The underlying discovery problem, which is why the behaviour was intermittent rather than simply absent.

Skill docs are written to `<workspace>/skills/aai-cli/<service>_skill.md`. On OpenClaw that is the **highest-precedence skill root** — but discovery matches the exact basename `SKILL.md` (`src/skills/runtime/refresh.ts:423`), so our files never enter the `<available_skills>` block that OpenClaw's own system prompt instructs the agent to scan. Hermes indexes `~/.hermes/skills/<name>/SKILL.md`; we write to `/workspace/skills/`, missing on both path and filename.

So on both runtimes the *only* pointer to these docs is prose the agent may or may not act on — which is exactly the coin-flip behaviour observed. Converting the seeded docs to real `SKILL.md` files with `name`/`description` frontmatter is the structural fix and wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
