### PR TITLE
AF-233: upgrade LiteLLM to v1.96.2 for OpenRouter cost tracking

### DIFF
--- a/helm/litellm/Chart.yaml
+++ b/helm/litellm/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: litellm
 description: LiteLLM proxy for agent-farm
-version: 0.3.0
+version: 0.4.0

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/berriai/litellm
-  tag: main-v1.83.14-stable.patch.3
+  tag: v1.96.2
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
Upgrades the LiteLLM proxy so that agent spend on streamed OpenRouter requests is recorded instead of logging as zero.

## What's included

- **`helm/litellm/values.yaml`** — image tag `main-v1.83.14-stable.patch.3` → `v1.96.2`. v1.83.14 dropped OpenRouter's provider-reported cost on streamed requests: OpenRouter sends its usage chunk, carrying the `cost` field, *after* the `finish_reason` chunk, and the stream handler raised `StopIteration` on the first post-finish chunk, so that chunk never reached the assembled response. Cost then fell back to a token-based estimate, which is zero for any model absent from the bundled cost map. Every model routed through our `openrouter/*` wildcard is absent from that map, including our default `openrouter/z-ai/glm-5.2`, so all agent spend logged as 0. Fixed upstream by BerriAI/litellm#32255, first released in v1.94.0.
- **`helm/litellm/Chart.yaml`** — chart `version` 0.3.0 → 0.4.0, per the operations guideline to bump when chart values change. `appVersion` deliberately untouched: LiteLLM runs an upstream image.

No template, config, or application changes. The `openrouter/*` wildcard routing, `store_model_in_db`, and master-key handling all work unchanged on the new version.

## Required repo config

None.

## Notes

- The tag drops the `main-` prefix and `-stable` suffix. LiteLLM retired `-stable` at v1.84.0; plain SemVer is now the stable channel and `v1.96.2` is the current stable release. `main-v1.96.2` does not exist on ghcr.
- The upgrade applies 23 new Prisma migrations. All are additive — 42 `ALTER TABLE` (add column), 12 `CREATE INDEX`, 7 `CREATE TABLE`, 4 `CREATE UNIQUE INDEX`, and zero `DROP`, type change, rename, or `SET NOT NULL`.
- Existing LiteLLM virtual keys survive the migration. The two migrations touching `LiteLLM_VerificationToken` add `budget_fallbacks` (`NOT NULL` with a `'{}'` default, so existing rows backfill) and `key_type` (nullable). `key_type` is read only at key generation; nothing in the auth path consults it.
- No Makefile target covers this change — `test-api`, `test-api-k8s`, `test-ui`, `lint-ui`, `check-ui`, `check-api` and `check-migrations` are all api/ui code, and `check-monitoring` only runs `helm/monitoring/tests/run.sh`.
- Follow-up worth its own ticket: `ci.yml` has no path rule for `helm/**` outside `helm/monitoring/`, so chart changes get a green CI run with every job skipped and no validation. The render checks below were run by hand for that reason.

## Testing

Chart rendering, exit codes verified directly:

- `helm lint helm/litellm` — exit 0
- `helm template litellm helm/litellm` — exit 0, renders `ghcr.io/berriai/litellm:v1.96.2`
- `helmfile template -l name=litellm` — exit 0

End-to-end on local k3d, same model and identical token counts, only the image tag changing:

| version | spend | tokens |
| --- | --- | --- |
| v1.83.14 | `0.0` | 33 |
| v1.96.2 | `4.270644e-05` | 33 |

The recorded spend matches the cost OpenRouter reported in the usage chunk. `openrouter/z-ai/glm-5.2` is absent from v1.96.2's bundled cost map, confirming the value comes from the provider passthrough rather than a map lookup. Also verified for `openrouter/deepseek/deepseek-v4-pro-0813`.

Migration and key-preservation test, on a separate database seeded at the pre-upgrade schema (118 migrations, one live key):

- After upgrade: 141 migrations applied, 0 failed, key row preserved, `key_type` `NULL`, `budget_fallbacks` `{}`
- The same key generated under v1.83.14 authenticated unchanged on v1.96.2 (HTTP 200) and recorded spend of `5.89e-05` against its key row