### PR TITLE
Rebrand Agent Farm → Agent Barn (docs & prose)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
-# Agent Farm
+# Agent Barn
 
-Agent Farm manages organization-owned AI agents that operate in Slack, Microsoft Teams, Telegram, or Discord through a selected runtime and a versioned configuration.
+Agent Barn manages organization-owned AI agents that operate in Slack, Microsoft Teams, Telegram, or Discord through a selected runtime and a versioned configuration.
 
 ## Language
 
@@ -21,7 +21,7 @@ The deployment-configured maximum number of non-deleted Organizations attributed
 _Avoid_: Membership limit, ownership limit, Platform Administrator quota
 
 **Platform Administrator**:
-A user with platform-level authority to administer Agent Farm outside any single Organization. A Platform Administrator may also have normal Memberships, but platform authority is separate from Organization Membership authority.
+A user with platform-level authority to administer Agent Barn outside any single Organization. A Platform Administrator may also have normal Memberships, but platform authority is separate from Organization Membership authority.
 _Avoid_: superuser, super admin, global role
 
 **Platform Privilege**:
@@ -29,7 +29,7 @@ The platform-level grant that makes a user a Platform Administrator.
 _Avoid_: global Membership, Organization Role, default Organization ownership
 
 **Platform Resource**:
-A global resource owned by Agent Farm itself rather than by an Organization.
+A global resource owned by Agent Barn itself rather than by an Organization.
 _Avoid_: default Organization resource, shared tenant data
 
 **Platform View**:
@@ -89,11 +89,11 @@ The models and token usage attributed to Agent executions during a defined repor
 _Avoid_: configured model, current model
 
 **Runtime**:
-The implementation that executes an agent. Agent Farm currently supports Hermes and OpenClaw.
+The implementation that executes an agent. Agent Barn currently supports Hermes and OpenClaw.
 _Avoid_: platform
 
 **Platform**:
-The chat system through which an agent interacts with people. Agent Farm currently supports Slack, Microsoft Teams, Telegram, and Discord.
+The chat system through which an agent interacts with people. Agent Barn currently supports Slack, Microsoft Teams, Telegram, and Discord.
 _Avoid_: runtime
 
 **Template**:
@@ -177,7 +177,7 @@ An ingested record of one external tool execution by an agent, with pending, suc
 _Avoid_: integration call
 
 **Domain Event**:
-An immutable, typed business fact that occurred at Platform or Organization scope and may be handled internally by Agent Farm.
+An immutable, typed business fact that occurred at Platform or Organization scope and may be handled internally by Agent Barn.
 _Avoid_: outbox row, telemetry event, audit log
 
 **Event Scope**:
@@ -217,7 +217,7 @@ A durable, immutable compliance artifact that records a security-relevant fact, 
 _Avoid_: domain event, audit event, log line
 
 **Ingest**:
-The separately served, authenticated telemetry path through which agent runtimes report conversation messages and tool-call state to Agent Farm.
+The separately served, authenticated telemetry path through which agent runtimes report conversation messages and tool-call state to Agent Barn.
 _Avoid_: webhook
 
 ## Relationships

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Agent Farm
+# Agent Barn
 
 Platform for hiring, managing, and running AI agents on Slack and Microsoft Teams.
 

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -6,7 +6,7 @@ Read before introducing a domain, moving ownership between domains, or changing 
 
 ## Source map
 
-Agent Farm is a monorepo with four operational areas:
+Agent Barn is a monorepo with four operational areas:
 
 | Area           | Responsibility                                                                                         | Authoritative sources                                                        |
 | -------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |

--- a/docs/features/costs.md
+++ b/docs/features/costs.md
@@ -6,7 +6,7 @@ Read before changing spend attribution, LiteLLM integration, cost summaries, del
 
 ## Role in the system
 
-Costs provides organization and per-agent spend views by querying LiteLLM and joining its key-based records to Agent Farm agents. Cost records are not persisted by the Costs domain.
+Costs provides organization and per-agent spend views by querying LiteLLM and joining its key-based records to Agent Barn agents. Cost records are not persisted by the Costs domain.
 
 ## Invariants
 

--- a/docs/features/domain-events.md
+++ b/docs/features/domain-events.md
@@ -6,7 +6,7 @@ Read before adding or changing internal Domain Events, Outbox Messages, Event De
 
 ## Role in the system
 
-Agent Farm uses internal Domain Events to record immutable, typed business facts at either Organization or Platform scope. A committed Domain Event is persisted as one PostgreSQL `event_outbox_message` row and one `event_delivery` row per currently registered Event Handler. PostgreSQL is the durable source for event intent and intended handler delivery state; Dramatiq/Redis is the low-latency, at-least-once transport for committed Event Deliveries.
+Agent Barn uses internal Domain Events to record immutable, typed business facts at either Organization or Platform scope. A committed Domain Event is persisted as one PostgreSQL `event_outbox_message` row and one `event_delivery` row per currently registered Event Handler. PostgreSQL is the durable source for event intent and intended handler delivery state; Dramatiq/Redis is the low-latency, at-least-once transport for committed Event Deliveries.
 
 ## Invariants
 

--- a/docs/features/identity-and-organizations.md
+++ b/docs/features/identity-and-organizations.md
@@ -17,7 +17,7 @@ Authentication establishes a user and membership context; Organization is the te
 - Organization-scoped routes carry the active organization in the URL. A route without an `organization_id` path parameter has no active Organization.
 - Org-scoped routes require real membership in the selected organization, including for Platform Administrators. Platform Administrator authority is reserved for platform routes.
 - Cross-organization resource access is intentionally hidden with 404 for tenant-owned entities; known but unauthorized organization administration uses 403.
-- Agent Farm has no default Organization. Platform-owned resources are global Platform Resources, not Organization-owned rows. Any organization with active agents must remove them before deletion.
+- Agent Barn has no default Organization. Platform-owned resources are global Platform Resources, not Organization-owned rows. Any organization with active agents must remove them before deletion.
 - Platform routes accept Platform Administrator authority only from an authenticated user session. API-key, service, runtime, and other non-user-session credential classes are denied even when they identify a Platform Administrator.
 - Platform Administrators can list users and organizations, provision pending users with an initial Organization, resend pending-user invitations, and grant or revoke Platform Privilege. Platform password reset, account deletion, and platform-level Organization creation/deletion are not supported.
 - Platform Privilege changes require a 1–1000 character reason, reject no-op changes, prohibit self-revocation, and cannot remove the final Platform Administrator. The user-state change and Platform-scoped Domain Event commit atomically.

--- a/ui/src/app/dashboard/[orgId]/costs/page.tsx
+++ b/ui/src/app/dashboard/[orgId]/costs/page.tsx
@@ -2,7 +2,7 @@ import { CostsDashboard } from "@/features/costs/components/costs-dashboard";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Costs | Agent Farm",
+  title: "Costs | Agent Barn",
 };
 
 export default function CostsPage() {


### PR DESCRIPTION
## Summary
- Renames product-name prose to **Agent Barn** in README, CONTEXT.md glossary, docs/architecture, docs/features, and the UI Costs page title.

## Deliberately out of scope (follow-up PRs)
- Namespaces (`agent-farm`/`agent-farm-staging`), helm charts (`helm/agentfarm-*`), k8s manifests, deploy.sh — PR3
- Code identifiers: `agentfarm_*` metrics + dashboards/alerts, `agentfarm.io` labels, Redis namespace, config defaults — PR2
- CI workflows & image repos — PR4
- Teams manifest `com.agentfarm.bot` packageName and `agent-farm.k8s.aai-labs.com` URLs (live endpoints) — cutover PR
- Historical ADRs left as-is

## Verification
- `tsc --noEmit` passes in ui/
- Remaining `agent.?farm` hits are functional identifiers still matching deployed code (doc/code sync preserved)