### PR TITLE
fix(ui): remove deleted organization immediately from query cache and user context (#153)

### DIFF
--- a/ui/src/features/organizations/hooks/use-organization-actions.ts
+++ b/ui/src/features/organizations/hooks/use-organization-actions.ts
@@ -7,8 +7,11 @@ import { toastError } from "@/shared/toast";
 import { agentsKey } from "@/features/agents/utils";
 import { currentUserContextKey } from "@/auth/utils";
 
+import type { CurrentUserContext } from "@/auth/schemas";
+import type { ApiResult } from "@/shared/api/types";
 import {
   type CreateOrganizationFormData,
+  type PaginatedPlatformOrganizations,
   OrganizationSchema,
 } from "../schemas";
 import { organizationsKey, platformOrganizationsKey } from "../utils";
@@ -39,10 +42,67 @@ export function useDeleteOrganization() {
   return useMutation({
     mutationFn: async (organizationId: string) => {
       await api.delete(`/api/v1/organizations/${organizationId}`);
+      return organizationId;
     },
-    onSuccess: () => {
+    onSuccess: (_, organizationId) => {
+      // 1. Immediately remove from platform organizations infinite queries
+      queryClient.setQueriesData<{
+        pageParams: unknown[];
+        pages: PaginatedPlatformOrganizations[];
+      }>({ queryKey: platformOrganizationsKey.lists() }, (old) => {
+        if (!old?.pages) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            items: page.items.filter((item) => item.id !== organizationId),
+            total: Math.max(0, page.total - 1),
+          })),
+        };
+      });
+
+      // 2. Immediately remove from platform organizations all query (used by org switcher for admins)
+      queryClient.setQueriesData<PaginatedPlatformOrganizations>(
+        { queryKey: platformOrganizationsKey.list({ scope: { mode: "all" } }) },
+        (old) => {
+          if (!old?.items) return old;
+          return {
+            ...old,
+            items: old.items.filter((item) => item.id !== organizationId),
+            total: Math.max(0, old.total - 1),
+          };
+        },
+      );
+
+      // 3. Immediately remove from current user context (memberships)
+      queryClient.setQueriesData<ApiResult<CurrentUserContext>>(
+        { queryKey: currentUserContextKey.all },
+        (old) => {
+          if (!old?.data?.organizationUsers) return old;
+          return {
+            ...old,
+            data: {
+              ...old.data,
+              organizationUsers: old.data.organizationUsers.filter(
+                (m) => m.organizationId !== organizationId,
+              ),
+            },
+          };
+        },
+      );
+
+      // 4. Remove cached details for the deleted organization
+      queryClient.removeQueries({
+        queryKey: organizationsKey.detail(organizationId),
+      });
+      queryClient.removeQueries({
+        queryKey: platformOrganizationsKey.detail(organizationId),
+      });
+
+      // 5. Invalidate queries to ensure background sync
       void queryClient.invalidateQueries({ queryKey: organizationsKey.lists() });
       void queryClient.invalidateQueries({ queryKey: platformOrganizationsKey.lists() });
+      void queryClient.invalidateQueries({ queryKey: currentUserContextKey.all });
     },
   });
 }


### PR DESCRIPTION
﻿## Summary

Fixes #153 — removes a deleted organization immediately from the UI list, infinite queries, and user organization context without requiring a manual page reload.

## Root Cause

`useDeleteOrganization` in `ui/src/features/organizations/hooks/use-organization-actions.ts` did not update cached query pages upon deletion and omitted `currentUserContextKey.all` invalidation. Consequently:
1. Active and cached infinite lists (`platformOrganizationsKey.lists()`) and the all-organizations query (`platformOrganizationsKey.list({ scope: { mode: "all" } })`) retained the deleted organization until the browser page was hard refreshed.
2. The `currentUserContext` cache (which drives `userContext.organizationUsers` in the OrgSwitcher and navbar) still listed the deleted organization.

## Solution

In `useDeleteOrganization.onSuccess`:
1. Updated `platformOrganizationsKey.lists()` infinite query pages via `queryClient.setQueriesData` to immediately filter out the deleted organization (`id !== organizationId`) and decrement `total`.
2. Updated `platformOrganizationsKey.list({ scope: { mode: "all" } })` to filter out the deleted item and decrement `total`.
3. Updated `currentUserContextKey.all` to immediately filter out `organizationUsers` where `organizationId === organizationId`.
4. Evicted cached detail queries (`organizationsKey.detail(organizationId)` and `platformOrganizationsKey.detail(organizationId)`).
5. Triggered background invalidation for `organizationsKey.lists()`, `platformOrganizationsKey.lists()`, and `currentUserContextKey.all`.

## Verification

- `npx tsc --noEmit`: 0 TypeScript errors.
- `npx next build`: production build completed cleanly with Turbopack (20/20 static and dynamic routes compiled successfully).

## Checklist
- [x] Deleted organization filtered out immediately from UI state
- [x] Cache synchronization for infinite lists and user context
- [x] TypeScript clean and production build passed
- [x] Staged as Draft PR
