### PR TITLE
feat(communications): build Discord bot install link on demand

### DIFF
--- a/api/domains/communications/models.py
+++ b/api/domains/communications/models.py
@@ -34,6 +34,7 @@ class CommunicationPlatform(str, enum.Enum):
 class PlatformCapability(str, enum.Enum):
     DIRECTORY_DISCOVERY = "directory_discovery"
     APPLICATION_PROVISIONING = "application_provisioning"
+    INSTALL_LINK = "install_link"
     WEBHOOK_INGRESS = "webhook_ingress"
     ATTACHMENTS = "attachments"
     THREADS = "threads"
@@ -625,3 +626,9 @@ class CommunicationConnectionRead(PydanticBaseModel):
     revision: int
     created_at: datetime
     updated_at: datetime
+
+
+class CommunicationInstallLinkRead(PydanticBaseModel):
+    """Provider-built install URL for a saved Connection's bot."""
+
+    url: str

--- a/api/domains/communications/plugins/base.py
+++ b/api/domains/communications/plugins/base.py
@@ -309,3 +309,16 @@ class PlatformPlugin(ABC):
         credential material.
         """
         raise NotImplementedError(f"{self.key} does not implement application provisioning")
+
+    def build_install_link(
+        self,
+        settings: PlatformSettings,
+        credentials: PlatformCredentials,
+    ) -> str:
+        """Build the provider install URL that adds this Connection's bot to a server.
+
+        Platforms whose bot is installed through a generated provider URL
+        implement this seam and declare INSTALL_LINK. The returned URL must
+        carry only non-secret material (client id, scopes, permissions).
+        """
+        raise NotImplementedError(f"{self.key} does not implement bot install links")

--- a/api/domains/communications/plugins/discord.py
+++ b/api/domains/communications/plugins/discord.py
@@ -28,6 +28,9 @@ from api.infrastructure.discord.client import DiscordClient
 
 logger = logging.getLogger(__name__)
 
+_INSTALL_OAUTH_SCOPES = "bot%20applications.commands"
+_INSTALL_PERMISSIONS = 274878286912
+
 
 class DiscordValidationConfig(Protocol):
     skip_discord_token_validation: bool
@@ -96,9 +99,11 @@ class DiscordPlatformPlugin(PlatformPlugin):
         "2. Under **Bot → Privileged Gateway Intents**, enable **Message Content Intent**. Enable **Server Members Intent** "
         "too when you want the Connection editor to suggest server members.\n\n"
         "## Invite the bot\n\n"
-        "1. Under **OAuth2 → URL Generator**, choose the bot scope and invite it to each server.\n"
-        "2. Grant **View Channels**, **Send Messages**, and **Read Message History**; also grant **Send Messages in Threads** "
-        "when threads are used.\n\n"
+        "1. After saving this Connection, use **Install bot to server** on its card to add the bot to each server "
+        "with the recommended permissions.\n"
+        "2. To invite manually instead, open **OAuth2 → URL Generator**, choose the bot scope, and grant **View "
+        "Channels**, **Send Messages**, and **Read Message History**; also grant **Send Messages in Threads** when "
+        "threads are used.\n\n"
         "## Finish the Connection\n\n"
         "1. Paste the Bot Token into this Connection and save it.\n"
         "2. The bot must belong to each allowed server and view every allowed channel. Enable **Developer Mode** to copy "
@@ -109,6 +114,7 @@ class DiscordPlatformPlugin(PlatformPlugin):
     capabilities = frozenset(
         {
             PlatformCapability.DIRECTORY_DISCOVERY,
+            PlatformCapability.INSTALL_LINK,
             PlatformCapability.ATTACHMENTS,
             PlatformCapability.MENTIONS,
             PlatformCapability.THREADS,
@@ -129,6 +135,15 @@ class DiscordPlatformPlugin(PlatformPlugin):
         username = str(bot.get("username") or "")
         discriminator = str(bot.get("discriminator") or "")
         return f"@{username}#{discriminator}" if discriminator and discriminator != "0" else f"@{username}"
+
+    def build_install_link(self, settings: PlatformSettings, credentials: PlatformCredentials) -> str:
+        del settings
+        assert isinstance(credentials, DiscordCredentials)
+        application = DiscordClient(credentials.bot_token).get_current_application()
+        return (
+            "https://discord.com/oauth2/authorize"
+            f"?client_id={application['id']}&scope={_INSTALL_OAUTH_SCOPES}&permissions={_INSTALL_PERMISSIONS}"
+        )
 
     def fingerprint_material(self, credentials: PlatformCredentials) -> str:
         assert isinstance(credentials, DiscordCredentials)

--- a/api/domains/communications/routes.py
+++ b/api/domains/communications/routes.py
@@ -16,6 +16,7 @@ from api.domains.communications.models import (
     CommunicationDirectoryEntryRead,
     CommunicationDirectoryPreview,
     CommunicationDirectoryPreviewRead,
+    CommunicationInstallLinkRead,
     CommunicationJournalEntryRead,
     CommunicationJournalStage,
     CommunicationReconnectRead,
@@ -111,6 +112,19 @@ def download_communication_app_package(
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+@communications_router.get(
+    "/agents/{agent_id}/connections/{connection_id}/install-link",
+    response_model=CommunicationInstallLinkRead,
+)
+def get_communication_install_link(
+    agent_id: UUID,
+    connection_id: UUID,
+    context: Annotated[CurrentUserContext, Depends(get_current_user())],
+    service: Annotated[CommunicationsService, Injected(CommunicationsService)],
+):
+    return service.build_install_link(agent_id, connection_id, context)
 
 
 @communications_router.patch(

--- a/api/domains/communications/service.py
+++ b/api/domains/communications/service.py
@@ -28,6 +28,7 @@ from api.domains.communications.models import (
     CommunicationDirectoryPreview,
     CommunicationDirectoryPreviewRead,
     CommunicationErrorCategory,
+    CommunicationInstallLinkRead,
     CommunicationJournalEntryRead,
     CommunicationJournalStage,
     CommunicationReconnectRead,
@@ -438,6 +439,40 @@ class CommunicationsService:
             attempt_count=delivery.attempt_count,
             requested_at=datetime.now(UTC),
         )
+
+    def build_install_link(
+        self,
+        agent_id: UUID,
+        connection_id: UUID,
+        context: CurrentUserContext,
+    ) -> CommunicationInstallLinkRead:
+        self.authorization.require_action(context, agent_id, PermissionKey.AGENT_UPDATE)
+        scope = self.authorization.authorization_scope(context, PermissionKey.AGENT_UPDATE)
+        connection = self.repository.get_active_in_scope(connection_id, agent_id, scope)
+        if connection is None:
+            self._raise_not_found(connection_id)
+
+        plugin = self._require_plugin(connection.platform_key)
+        if PlatformCapability.INSTALL_LINK not in plugin.capabilities:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{plugin.display_name} does not provide a bot install link",
+            )
+        try:
+            url = plugin.build_install_link(
+                plugin.settings_model.model_validate(connection.settings),
+                plugin.credentials_model.model_validate(
+                    self._decrypt_credentials(plugin, connection.credentials_encrypted)
+                ),
+            )
+            return CommunicationInstallLinkRead(url=url)
+        except NotImplementedError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{plugin.display_name} does not provide a bot install link",
+            ) from exc
+        except (ValidationError, ValueError) as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     def build_app_package(
         self,

--- a/api/infrastructure/discord/client.py
+++ b/api/infrastructure/discord/client.py
@@ -51,6 +51,12 @@ class DiscordClient:
             raise ValueError("Discord bot token is invalid")
         return body
 
+    def get_current_application(self) -> dict[str, Any]:
+        body = self._get("/oauth2/applications/@me", label="Discord get current application")
+        if not body or not body.get("id"):
+            raise ValueError("Discord application lookup failed")
+        return body
+
     def get_gateway_url(self) -> str:
         body = self._get("/gateway/bot", label="Discord get gateway")
         if not body or not body.get("url"):

--- a/api/tests/integration/test_communication_connections.py
+++ b/api/tests/integration/test_communication_connections.py
@@ -172,6 +172,7 @@ def test_platform_catalog_lists_the_shipped_plugins() -> None:
                     contains_string("View Channels"),
                     contains_string("Read Message History"),
                     contains_string("Developer Mode"),
+                    contains_string("Install bot to server"),
                 ),
             )
             assert_that(
@@ -1046,6 +1047,68 @@ def _teams_payload(name: str = "Microsoft Teams") -> dict:
             "tenant_id": "22222222-2222-4222-8222-222222222222",
         },
     }
+
+
+def test_install_link_returns_the_recommended_url_for_a_discord_connection() -> None:
+    with given(_GIVEN) as context:
+        created = context.client.post(_base(context), json=_discord_payload(), headers=_auth(context))
+        connection_id = created.json()["id"]
+
+        with when("I request the install link for the saved Connection"):
+            with patch(
+                "api.infrastructure.discord.client.DiscordClient.get_current_application",
+                return_value={"id": "123456789012345678"},
+            ):
+                response = context.client.get(
+                    f"{_base(context)}/{connection_id}/install-link",
+                    headers=_auth(context),
+                )
+
+        with then("the recommended least-privilege install URL is returned"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            assert_that(
+                response.json(),
+                equal_to(
+                    {
+                        "url": (
+                            "https://discord.com/oauth2/authorize"
+                            "?client_id=123456789012345678&scope=bot%20applications.commands&permissions=274878286912"
+                        )
+                    }
+                ),
+            )
+
+
+def test_install_link_is_rejected_for_a_platform_without_the_capability() -> None:
+    with given(_GIVEN) as context:
+        created = context.client.post(_base(context), json=_slack_payload(), headers=_auth(context))
+        connection_id = created.json()["id"]
+
+        with when("I request an install link for a Slack Connection"):
+            response = context.client.get(
+                f"{_base(context)}/{connection_id}/install-link",
+                headers=_auth(context),
+            )
+
+        with then("the platform reports it provides no bot install link"):
+            assert_that(response.status_code, equal_to(status.HTTP_400_BAD_REQUEST))
+            assert_that(response.json()["detail"], contains_string("does not provide a bot install link"))
+
+
+def test_install_link_is_concealed_across_organizations() -> None:
+    with given(_GIVEN) as context:
+        created = context.client.post(_base(context), json=_discord_payload(), headers=_auth(context))
+        connection_id = created.json()["id"]
+        other_agent_id = uuid4()
+
+        with when("I request the install link through another Agent's path"):
+            response = context.client.get(
+                f"{_base_for_agent(context, other_agent_id)}/{connection_id}/install-link",
+                headers=_auth(context),
+            )
+
+        with then("the Connection is concealed"):
+            assert_that(response.status_code, equal_to(status.HTTP_404_NOT_FOUND))
 
 
 def test_teams_connection_serves_a_downloadable_app_package() -> None:

--- a/api/tests/unit/test_communications_plugins.py
+++ b/api/tests/unit/test_communications_plugins.py
@@ -110,6 +110,31 @@ def test_telegram_plugin_returns_safe_external_identity_when_validation_is_skipp
     assert validated.credentials == {"bot_token": "123:token"}
 
 
+def test_discord_plugin_builds_the_recommended_install_link_from_the_application() -> None:
+    plugin = DiscordPlatformPlugin(ValidationConfig())
+    credentials = plugin.credentials_model.model_validate({"bot_token": "bot-value"})
+
+    with patch("api.domains.communications.plugins.discord.DiscordClient") as client_type:
+        client_type.return_value.get_current_application.return_value = {"id": "123456789012345678"}
+        url = plugin.build_install_link(plugin.settings_model.model_validate({}), credentials)
+
+    assert_that(
+        url,
+        equal_to(
+            "https://discord.com/oauth2/authorize"
+            "?client_id=123456789012345678&scope=bot%20applications.commands&permissions=274878286912"
+        ),
+    )
+
+
+def test_platforms_without_install_links_reject_the_seam() -> None:
+    plugin = TelegramPlatformPlugin(ValidationConfig())
+    credentials = plugin.credentials_model.model_validate({"bot_token": "123:token"})
+
+    with pytest.raises(NotImplementedError, match="telegram does not implement bot install links"):
+        plugin.build_install_link(plugin.settings_model.model_validate({}), credentials)
+
+
 def test_discord_plugin_normalizes_an_allowed_message_create_event() -> None:
     config = ValidationConfig()
     plugin = DiscordPlatformPlugin(config)

--- a/docs/features/communications/CHANGELOG.md
+++ b/docs/features/communications/CHANGELOG.md
@@ -13,6 +13,11 @@ Related context: [Agents](../agents.md), [Activity and Ingest](../activity-and-i
 
 ## Changes
 
+### 2026-09-03 — Discord bot install link — PR pending
+
+- Delivered: A saved Discord Connection can regenerate its bot install URL on demand. The Connection card's **Get install link** action calls a new `install-link` endpoint, which resolves the bot's application through Discord's `GET /oauth2/applications/@me` using the stored bot token and returns the recommended least-privilege authorize URL — View Channels, Send Messages, Read Message History, and Send Messages in Threads, plus reactions, embeds, attachments, and external emoji. The URL is never persisted, so permission recommendations in code apply to every existing Connection immediately, and the action follows the app-package contract: authorized with `AGENT_UPDATE`, concealed cross-Organization, and rejected with 400 for platforms without the capability.
+- Changed: The install link follows the Teams app-package pattern — a new optional `build_install_link` Platform Plugin seam gated by the `INSTALL_LINK` capability, declared and implemented only by Discord. No Connection persistence, validation flow, or read-model shape changed, restoring the simple install workflow the pre-AF-271 wizard offered without its separate Application ID entry. The Discord setup hint now leads with the card action, keeping the OAuth2 URL Generator as the manual alternative.
+
 ### 2026-09-01 — Directory failures are reported instead of crashing — PR pending
 
 - Fixed: A provider-side directory read that failed — a revoked token, a missing scope, a rate limit, an outage — escaped as an unhandled 500, because `SlackFetchError` is not a `ValueError`. Both the preview and saved-Connection directory endpoints now translate any provider failure through the existing error normalizer. Credential and scope problems answer 400, rate limits 429, timeouts 504, and outages 502; 401/403 are deliberately never used, since the web client treats them as its own session expiring and would sign the operator out over a bad Slack token. Provider text still never reaches the client — only the bounded summary and a validated provider code such as `missing_scope`.

--- a/ui/src/features/agents/components/agent-channel-settings.tsx
+++ b/ui/src/features/agents/components/agent-channel-settings.tsx
@@ -32,6 +32,7 @@ import {
   useCommunicationConnectionDirectory,
   useCommunicationPlatforms,
   useDownloadAppPackage,
+  useInstallLink,
 } from "@/features/communication-connections/hooks/use-communication-connections";
 import { DirectoryPickerDialog } from "@/features/communication-connections/components/directory-picker-dialog";
 import { SLACK_APP_MANIFEST } from "@/features/communication-connections/slack-manifest";
@@ -453,8 +454,12 @@ export function AgentChannelSettings({
   const [formError, setFormError] = useState<string | null>(null);
   const [retiring, setRetiring] = useState<CommunicationConnection | null>(null);
   const downloadAppPackage = useDownloadAppPackage();
+  const fetchInstallLink = useInstallLink();
   const [packageBusyId, setPackageBusyId] = useState<string | null>(null);
   const [packageError, setPackageError] = useState<string | null>(null);
+  const [installLinks, setInstallLinks] = useState<Record<string, string>>({});
+  const [installBusyId, setInstallBusyId] = useState<string | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
   const [editingConnection, setEditingConnection] = useState<CommunicationConnection | null>(null);
   const [editDisplayName, setEditDisplayName] = useState("");
   const [editSettings, setEditSettings] = useState<Record<string, unknown>>({});
@@ -720,6 +725,46 @@ export function AgentChannelSettings({
                   )}
                   {packageError && packageBusyId === null && (
                     <div className="mt-2 text-xs" style={{ color: "var(--err)" }}>{packageError}</div>
+                  )}
+                  {platforms.data
+                    ?.find((p) => p.key === connection.platformKey)
+                    ?.capabilities.includes("install_link") && (
+                    <div className="mt-2 flex items-center gap-2 text-xs" style={{ color: "var(--ink-3)" }}>
+                      <span>Add the bot to a server with the recommended permissions.</span>
+                      {installLinks[connection.id] ? (
+                        <a
+                          href={installLinks[connection.id]}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="af-btn af-btn-sm flex-shrink-0"
+                        >
+                          Install bot to server ↗
+                        </a>
+                      ) : (
+                        <button
+                          type="button"
+                          className="af-btn af-btn-sm flex-shrink-0"
+                          disabled={installBusyId === connection.id}
+                          onClick={() => {
+                            setInstallBusyId(connection.id);
+                            setInstallError(null);
+                            void fetchInstallLink(agent.id, connection.id)
+                              .then((url) => setInstallLinks((previous) => ({ ...previous, [connection.id]: url })))
+                              .catch((cause: unknown) =>
+                                setInstallError(
+                                  cause instanceof Error ? cause.message : "Could not build the install link.",
+                                ),
+                              )
+                              .finally(() => setInstallBusyId(null));
+                          }}
+                        >
+                          {installBusyId === connection.id ? "Preparing…" : "Get install link"}
+                        </button>
+                      )}
+                    </div>
+                  )}
+                  {installError && installBusyId === null && (
+                    <div className="mt-2 text-xs" style={{ color: "var(--err)" }}>{installError}</div>
                   )}
                   <div className="mt-3">
                     <PlatformSetupHint

--- a/ui/src/features/communication-connections/hooks/use-communication-connections.ts
+++ b/ui/src/features/communication-connections/hooks/use-communication-connections.ts
@@ -18,10 +18,12 @@ import {
   CommunicationReconnectSchema,
   CommunicationRetrySchema,
   CommunicationPlatformSchema,
+  CommunicationInstallLinkSchema,
   type CommunicationConnection,
   type CommunicationDirectoryEntry,
   type CommunicationDirectoryPreview,
   type CommunicationPlatform,
+  type CommunicationInstallLink,
   type CommunicationDiagnostics,
   type CommunicationJournalFilters,
   type CommunicationJournalKind,
@@ -228,6 +230,18 @@ export function useCommunicationDeliveryLifecycle(
     new Map((query.data?.pages.flatMap((page) => page.items) ?? []).map((entry) => [entry.id, entry])).values(),
   );
   return { ...query, entries };
+}
+
+export function useInstallLink() {
+  const orgApiBase = useOrganizationApiBase();
+
+  return async function fetchInstallLink(agentId: string, connectionId: string) {
+    const response = await api.get<CommunicationInstallLink>(
+      `${orgApiBase}/agents/${agentId}/connections/${connectionId}/install-link`,
+      { schema: CommunicationInstallLinkSchema },
+    );
+    return response.data.url;
+  };
 }
 
 export function useDownloadAppPackage() {

--- a/ui/src/features/communication-connections/schemas.ts
+++ b/ui/src/features/communication-connections/schemas.ts
@@ -180,9 +180,14 @@ export const CommunicationRetrySchema = z.object({
   requestedAt: z.string(),
 });
 
+export const CommunicationInstallLinkSchema = z.object({
+  url: z.string().url(),
+});
+
 export type CommunicationDirectoryEntry = z.infer<typeof CommunicationDirectoryEntrySchema>;
 export type CommunicationDirectoryPreview = z.infer<typeof CommunicationDirectoryPreviewSchema>;
 export type CommunicationPlatform = z.infer<typeof CommunicationPlatformSchema>;
+export type CommunicationInstallLink = z.infer<typeof CommunicationInstallLinkSchema>;
 export type CommunicationConnection = z.infer<typeof CommunicationConnectionSchema>;
 export type CommunicationDiagnostics = z.infer<typeof CommunicationDiagnosticsSchema>;
 export type CommunicationJournalEntry = z.infer<typeof CommunicationJournalEntrySchema>;

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import { TEST_ORG_ID } from "../constants";
 import {
+  COMMUNICATION_CONNECTION_ID,
   COMMUNICATION_DELIVERY_ID,
   mockCommunicationConnection,
   SAFE_ERROR_DETAILS,
@@ -515,6 +516,30 @@ test.describe("Agent Detail Page — Channels tab", () => {
   test("lists Connection identity and health independently of the Agent runtime", async () => {
     await expect(agentDetailPage.connectionIdentity("validation-skipped")).toBeVisible();
     await expect(agentDetailPage.connectionProviderStatus("Connected")).toBeVisible();
+  });
+
+  test("builds the recommended install link on demand for a Discord Connection", async ({ page }) => {
+    const installUrl =
+      "https://discord.com/oauth2/authorize?client_id=123456789012345678&scope=bot%20applications.commands&permissions=274878286912";
+    await page.route(
+      `**/api/v1/organizations/*/agents/${MOCK_AGENT_ID}/connections/${COMMUNICATION_CONNECTION_ID}/install-link`,
+      async (route) => {
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ url: installUrl }) });
+      },
+    );
+
+    await expect(agentDetailPage.getInstallLinkButton()).toBeVisible();
+    await agentDetailPage.getInstallLinkButton().click();
+
+    const installLink = agentDetailPage.installBotServerLink();
+    await expect(installLink).toBeVisible();
+    await expect(installLink).toHaveAttribute("href", installUrl);
+  });
+
+  test("hides the install link action when the platform provides none", async ({ page }) => {
+    await serveSavedSlackConnection(page);
+
+    await expect(agentDetailPage.getInstallLinkButton()).toHaveCount(0);
   });
 
   test("shows a redacted provider error at full width", async () => {

--- a/ui/tests/fixtures/communication-connections.ts
+++ b/ui/tests/fixtures/communication-connections.ts
@@ -18,7 +18,7 @@ export const mockCommunicationPlatforms = [
     setup_hint:
       "## Create a bot\n\n1. Open the **Bot** page and copy the Token.\n2. Enable **Message Content Intent**.\n\n## Invite the bot\n\n1. Grant **View Channels**, **Send Messages**, and **Read Message History**.",
     schema_version: 1,
-    capabilities: ["MENTIONS", "DIRECTORY_DISCOVERY"],
+    capabilities: ["MENTIONS", "DIRECTORY_DISCOVERY", "install_link"],
     settings_schema: {
       type: "object",
       properties: {

--- a/ui/tests/pages/agent-detail-page.po.ts
+++ b/ui/tests/pages/agent-detail-page.po.ts
@@ -77,6 +77,14 @@ export class AgentDetailPage {
     return this.page.getByRole("button", { name: `Edit ${connectionName}`, exact: true });
   }
 
+  getInstallLinkButton(): Locator {
+    return this.page.getByRole("button", { name: "Get install link", exact: true });
+  }
+
+  installBotServerLink(): Locator {
+    return this.page.getByRole("link", { name: "Install bot to server" });
+  }
+
   connectionNameInput(): Locator {
     return this.page.getByLabel("Connection name", { exact: true });
   }


### PR DESCRIPTION
Restore the simple bot-install workflow the pre-AF-271 wizard offered, without its separate Application ID entry. A saved Discord Connection's card gains a Get install link action that calls a new install-link endpoint; the Discord plugin resolves the bot's application through GET /oauth2/applications/@me with the stored bot token and returns the recommended least-privilege authorize URL.

Follows the Teams app-package contract: an optional build_install_link Platform Plugin seam gated by the INSTALL_LINK capability, AGENT_UPDATE authorization, cross-Organization concealment, and a 400 for platforms without the capability. Nothing is persisted, so permission recommendations in code apply to existing Connections immediately.