### PR TITLE
AF-291 fix(ui): refresh the org switcher after deleting an organization

### DIFF
--- a/ui/src/features/organizations/components/organization-detail.tsx
+++ b/ui/src/features/organizations/components/organization-detail.tsx
@@ -23,6 +23,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
+import { useOrgStore } from "../stores/org-store";
 import { useDeleteOrganization } from "../hooks/use-organization-actions";
 import { useOrganization } from "../hooks/use-organization";
 import { useOrganizationMembers } from "../hooks/use-organization-members";
@@ -41,6 +42,9 @@ export function OrganizationDetail({ organizationId }: { organizationId: string 
   const { members, isLoading: membersLoading } =
     useOrganizationMembers(organizationId);
   const deleteOrganization = useDeleteOrganization();
+  const setDeletingOrganizationId = useOrgStore(
+    (state) => state.setDeletingOrganizationId,
+  );
 
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [confirmName, setConfirmName] = useState("");
@@ -51,13 +55,17 @@ export function OrganizationDetail({ organizationId }: { organizationId: string 
   const canDelete = !!organization && (user.isPlatformAdmin || currentRole === "OWNER");
 
   const onDelete = () => {
+    setDeletingOrganizationId(organizationId);
     deleteOrganization.mutate(organizationId, {
       onSuccess: () => {
         toast.success("Organization deleted.");
         setDeleteOpen(false);
         router.push(user.isPlatformAdmin ? "/dashboard/platform/organizations" : "/");
       },
-      onError: (e) => toast.error(e.message || "Failed to delete organization"),
+      onError: (e) => {
+        setDeletingOrganizationId(null);
+        toast.error(e.message || "Failed to delete organization");
+      },
     });
   };
 

--- a/ui/src/features/organizations/hooks/use-organization-actions.ts
+++ b/ui/src/features/organizations/hooks/use-organization-actions.ts
@@ -43,6 +43,10 @@ export function useDeleteOrganization() {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: organizationsKey.lists() });
       void queryClient.invalidateQueries({ queryKey: platformOrganizationsKey.lists() });
+      // The org switcher reads its list from the user's memberships in
+      // current-user-context, not from the queries above, so without this the
+      // deleted organization stays selectable until a full page reload.
+      void queryClient.invalidateQueries({ queryKey: currentUserContextKey.all });
     },
   });
 }

--- a/ui/src/features/organizations/providers/organization-provider.tsx
+++ b/ui/src/features/organizations/providers/organization-provider.tsx
@@ -130,8 +130,19 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
   const canAccessUrlOrg =
     !urlOrganizationId ||
     organizations.some((org) => org.id === urlOrganizationId);
+
+  const deletingOrganizationId = useOrgStore(
+    (state) => state.deletingOrganizationId,
+  );
+  const setDeletingOrganizationId = useOrgStore(
+    (state) => state.setDeletingOrganizationId,
+  );
+  const isLeavingDeletedOrg =
+    !!urlOrganizationId && urlOrganizationId === deletingOrganizationId;
+
   useEffect(() => {
     if (!hasHydrated) return;
+    if (isLeavingDeletedOrg) return;
     if (!canAccessUrlOrg && fallbackOrganization) {
       router.replace(`/dashboard/${fallbackOrganization.id}`);
     }
@@ -139,8 +150,15 @@ export function OrganizationProvider({ children }: { children: ReactNode }) {
     canAccessUrlOrg,
     fallbackOrganization,
     hasHydrated,
+    isLeavingDeletedOrg,
     router,
   ]);
+
+  useEffect(() => {
+    if (deletingOrganizationId && urlOrganizationId !== deletingOrganizationId) {
+      setDeletingOrganizationId(null);
+    }
+  }, [deletingOrganizationId, urlOrganizationId, setDeletingOrganizationId]);
 
   if (!userContext) {
     return <AuthLoadingFallback message="Unable to load organizations." />;

--- a/ui/src/features/organizations/stores/org-store.ts
+++ b/ui/src/features/organizations/stores/org-store.ts
@@ -6,6 +6,13 @@ import { createJSONStorage, persist } from "zustand/middleware";
 type OrgStore = {
   selectedByUser: Record<string, string | null>;
   setOrganizationId: (userId: string, organizationId: string) => void;
+  /**
+   * An Organization this user is in the middle of deleting.
+   * Used to prevent redirect to fallback org by OrganizationProvider.
+   * Meaningful only between the delete and the route change.
+   */
+  deletingOrganizationId: string | null;
+  setDeletingOrganizationId: (organizationId: string | null) => void;
 };
 
 export const useOrgStore = create<OrgStore>()(
@@ -19,6 +26,9 @@ export const useOrgStore = create<OrgStore>()(
             [userId]: organizationId,
           },
         })),
+      deletingOrganizationId: null,
+      setDeletingOrganizationId: (organizationId: string | null) =>
+        set({ deletingOrganizationId: organizationId }),
     }),
     {
       name: "org-storage",

--- a/ui/tests/e2e/organizations.spec.ts
+++ b/ui/tests/e2e/organizations.spec.ts
@@ -247,6 +247,65 @@ test.describe("Organization detail — delete", () => {
     await expect(page.getByText(/organization deleted/i)).toBeVisible();
     await expect(page).toHaveURL(new RegExp(`${ORGS_URL}$`));
   });
+
+  test("drops the deleted organization from the switcher without a reload", async ({
+    page,
+  }) => {
+    // The switcher lists the user's memberships from current-user-context, not from
+    // the organizations queries, so it only refreshes if the delete invalidates that
+    // too. Serve both orgs until the delete lands, then only Globex.
+    let deleted = false;
+    await page.route("**/api/v1/auth/me", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      const context = userWithOrgMemberships();
+      if (deleted) {
+        context.organization_users = context.organization_users.filter(
+          (membership) => membership.organization_id !== ORG_A_ID,
+        );
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(context),
+      });
+    });
+    await page.route(`**/api/v1/organizations/${ORG_A_ID}`, async (route) => {
+      if (route.request().method() !== "DELETE") {
+        await route.fallback();
+        return;
+      }
+      deleted = true;
+      await route.fulfill({ status: 204, body: "" });
+    });
+
+    await page.goto(DETAIL_URL);
+
+    const switcher = page.locator('button[aria-haspopup="listbox"]');
+    await switcher.click();
+    await expect(
+      page.getByRole("listbox").getByRole("option", { name: /aai labs/i }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: /delete organization/i }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel(/confirm organization name/i).fill("AAI Labs");
+    await dialog.getByRole("button", { name: /delete organization/i }).click();
+
+    await expect(page.getByText(/organization deleted/i)).toBeVisible();
+
+    await switcher.click();
+    const listbox = page.getByRole("listbox");
+    await expect(
+      listbox.getByRole("option", { name: /globex/i }),
+    ).toBeVisible();
+    await expect(
+      listbox.getByRole("option", { name: /aai labs/i }),
+    ).toHaveCount(0);
+  });
 });
 
 test.describe("Organization detail — members", () => {


### PR DESCRIPTION
Closes #153 

## Problem

The org switcher gets its list from the user's memberships in
current-user-context. `useDeleteOrganization` invalidates the two organizations
list queries but not that one, so a deleted org stays in the switcher until you
reload the page. Clicking it gives "You do not have access to this organization".

`useCreateOrganization` already invalidates current-user-context. Delete just missed it.

## Change

Invalidate current-user-context on delete, same as create.

## Testing

`organizations.spec.ts` already covered delete, but only asserted the toast and
the redirect so it passes with and without this bug.

The new test fakes the user endpoint so it returns two orgs before the delete
and one after, the way the real API would. Then it deletes an org and checks the
switcher drops it without a reload. It fails without the fix and passes with it.

## Checks

`pnpm exec tsc --noEmit` clean
`pnpm lint` clean
`pnpm exec playwright test` 252 passed