### PR TITLE
AF-290 fix(ui): collapse the top nav into a drawer on mobile and tablet screens

### DIFF
--- a/ui/src/components/top-nav.tsx
+++ b/ui/src/components/top-nav.tsx
@@ -54,7 +54,10 @@ export function TopNav({ onHire }: TopNavProps) {
         { href: `${orgBase}/settings`, label: "Settings" },
       ];
   const [menuOpen, setMenuOpen] = useState(false);
-  const [navOpen, setNavOpen] = useState(false);
+  const routeKey = pathname ?? "";
+  const [navOpenedOn, setNavOpenedOn] = useState<string | null>(null);
+  const navOpen = navOpenedOn !== null && navOpenedOn === routeKey;
+  const setNavOpen = (open: boolean) => setNavOpenedOn(open ? routeKey : null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/ui/src/components/top-nav.tsx
+++ b/ui/src/components/top-nav.tsx
@@ -19,6 +19,8 @@ import { OrgSwitcher } from "@/features/organizations/components/org-switcher";
 import { useActiveOrgRole } from "@/features/organizations/hooks/use-active-org-role";
 import { useOrganizationContext } from "@/features/organizations/providers/organization-provider";
 
+const PLATFORM_BASE = "/dashboard/platform";
+
 interface TopNavProps {
   onHire: () => void;
 }
@@ -32,14 +34,14 @@ export function TopNav({ onHire }: TopNavProps) {
 
   const orgId = selectedOrganization?.id;
   const orgBase = orgId ? `/dashboard/${orgId}` : "/dashboard";
-  const isPlatformView = pathname?.startsWith("/dashboard/platform") ?? false;
+  const isPlatformView = pathname?.startsWith(PLATFORM_BASE) ?? false;
 
   // Owners/admins (and platform admins) manage members and see org spend; plain members can't.
   const { canManage: canManageMembers } = useActiveOrgRole();
 
   const navTabs = isPlatformView
     ? [
-        { href: "/dashboard/platform", label: "Overview" },
+        { href: PLATFORM_BASE, label: "Overview" },
         { href: "/dashboard/platform/users", label: "Users" },
         { href: "/dashboard/platform/organizations", label: "Organizations" },
         { href: "/dashboard/platform/event-deliveries", label: "Event Deliveries" },
@@ -78,9 +80,14 @@ export function TopNav({ onHire }: TopNavProps) {
     .toUpperCase();
 
   const isActive = (href: string) => {
-    // Home matches the org root and its agent pages; other tabs match their subtree.
+    // Home and Overview are prefixes of every tab beside them, so a prefix test would
+    // report them active on every page in their section. Both match exactly instead —
+    // Home additionally claims the agent pages, which have no tab of their own.
     if (href === orgBase) {
       return pathname === orgBase || pathname.startsWith(`${orgBase}/agents`);
+    }
+    if (href === PLATFORM_BASE) {
+      return pathname === PLATFORM_BASE;
     }
     return pathname.startsWith(href);
   };
@@ -151,6 +158,7 @@ export function TopNav({ onHire }: TopNavProps) {
               fontWeight: isActive(href) ? 600 : 500,
               background: "transparent",
             }}
+            aria-current={isActive(href) ? "page" : undefined}
             onMouseEnter={(e) => {
               if (!isActive(href))
                 (e.currentTarget as HTMLElement).style.background = "var(--bg-soft)";

--- a/ui/src/components/top-nav.tsx
+++ b/ui/src/components/top-nav.tsx
@@ -6,8 +6,15 @@ import { usePathname, useRouter } from "next/navigation";
 import { useCurrentUser } from "@/auth/providers/user-context-provider";
 import { useLogout } from "@/auth/hooks/use-logout";
 import { PlusIcon, UserIcon, UsersIcon, BuildingIcon, LogOutIcon, ShieldIcon, ServerIcon } from "@/components/icons";
-import { FileText, Receipt, Sparkles } from "lucide-react";
+import { FileText, Menu, Receipt, Sparkles } from "lucide-react";
 import { LogoMark } from "@/components/logo-mark";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { OrgSwitcher } from "@/features/organizations/components/org-switcher";
 import { useActiveOrgRole } from "@/features/organizations/hooks/use-active-org-role";
 import { useOrganizationContext } from "@/features/organizations/providers/organization-provider";
@@ -47,6 +54,7 @@ export function TopNav({ onHire }: TopNavProps) {
         { href: `${orgBase}/settings`, label: "Settings" },
       ];
   const [menuOpen, setMenuOpen] = useState(false);
+  const [navOpen, setNavOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -76,22 +84,65 @@ export function TopNav({ onHire }: TopNavProps) {
 
   return (
     <header
-      className="flex items-center gap-9 px-10 sticky top-0 z-10 h-[61px] flex-shrink-0"
+      className="flex items-center gap-4 px-4 lg:gap-6 lg:px-6 xl:gap-9 xl:px-10 sticky top-0 z-10 h-[61px] flex-shrink-0"
       style={{ borderBottom: "1px solid var(--line)", background: "var(--bg)" }}
     >
-      <div className="flex items-center gap-2.5 font-semibold text-[15.5px] tracking-tight" style={{ color: "var(--ink)" }}>
+      <Sheet open={navOpen} onOpenChange={setNavOpen}>
+        <SheetTrigger
+          className="af-hover-bg -ml-1.5 grid h-9 w-9 flex-shrink-0 place-items-center rounded-lg lg:hidden"
+          style={{ color: "var(--ink-2)" }}
+          aria-label="Open navigation"
+        >
+          <Menu size={18} />
+        </SheetTrigger>
+
+        <SheetContent side="left" className="w-[17rem] p-0">
+          <SheetHeader className="px-4 pb-1 pt-4">
+            <SheetTitle
+              className="text-[11px] font-semibold uppercase tracking-[0.08em]"
+              style={{ color: "var(--ink-5)" }}
+            >
+              {isPlatformView ? "Platform" : "Navigation"}
+            </SheetTitle>
+          </SheetHeader>
+
+          <nav className="flex flex-col gap-0.5 px-2 pb-4">
+            {navTabs.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className="af-hover-bg rounded-lg px-3.5 py-2.5 text-[14px] transition-colors"
+                style={{
+                  color: isActive(href) ? "var(--ink)" : "var(--ink-2)",
+                  fontWeight: isActive(href) ? 600 : 500,
+                  background: isActive(href) ? "var(--bg-soft)" : "transparent",
+                }}
+                aria-current={isActive(href) ? "page" : undefined}
+                onClick={() => setNavOpen(false)}
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </SheetContent>
+      </Sheet>
+
+      <div
+        className="flex flex-shrink-0 items-center gap-2.5 font-semibold text-[15.5px] tracking-tight"
+        style={{ color: "var(--ink)" }}
+      >
         <LogoMark size={26} />
-        Agent Barn
+        <span className="hidden sm:inline">Agent Barn</span>
       </div>
 
       <OrgSwitcher />
 
-      <nav className="flex gap-0.5 flex-1">
+      <nav className="no-scrollbar hidden min-w-0 flex-1 gap-0.5 overflow-x-auto lg:flex">
         {navTabs.map(({ href, label }) => (
           <Link
             key={href}
             href={href}
-            className="px-3.5 py-[7px] rounded-lg text-[14px] font-medium transition-colors"
+            className="flex-shrink-0 whitespace-nowrap px-2.5 xl:px-3.5 py-[7px] rounded-lg text-[14px] font-medium transition-colors"
             style={{
               color: isActive(href) ? "var(--ink)" : "var(--ink-3)",
               fontWeight: isActive(href) ? 600 : 500,
@@ -110,10 +161,13 @@ export function TopNav({ onHire }: TopNavProps) {
         ))}
       </nav>
 
-      <div className="flex items-center gap-2.5">
+      {/* The drawer carries the tabs below lg, so keep the actions right-aligned. */}
+      <div className="flex-1 lg:hidden" />
+
+      <div className="flex flex-shrink-0 items-center gap-2.5">
         {!isPlatformView && (
-          <button className="af-btn af-btn-primary" onClick={onHire}>
-          <PlusIcon /> Hire agent
+          <button className="af-btn af-btn-primary" onClick={onHire} aria-label="Hire agent">
+            <PlusIcon /> <span className="hidden sm:inline">Hire agent</span>
           </button>
         )}
         <div ref={menuRef} className="relative">

--- a/ui/src/features/organizations/components/org-switcher.tsx
+++ b/ui/src/features/organizations/components/org-switcher.tsx
@@ -62,7 +62,7 @@ export function OrgSwitcher() {
 
   return (
     <>
-      <div ref={ref} className="relative flex items-center gap-1.5">
+      <div ref={ref} className="relative flex min-w-0 items-center gap-1.5">
         <span className="text-[13px]" style={{ color: "var(--ink-5)" }}>
           /
         </span>
@@ -73,7 +73,7 @@ export function OrgSwitcher() {
           aria-haspopup="listbox"
           aria-expanded={open}
         >
-          <span className="max-w-[180px] truncate font-medium">
+          <span className="max-w-[110px] truncate font-medium sm:max-w-[180px]">
             {isPlatformView
               ? "Platform"
               : selectedOrganization?.name ?? "Organizations"}

--- a/ui/tests/e2e/top-nav-responsive.spec.ts
+++ b/ui/tests/e2e/top-nav-responsive.spec.ts
@@ -101,6 +101,38 @@ test.describe("Top nav responsiveness", () => {
     });
   });
 
+  test.describe("active tab", () => {
+    test.use({ viewport: { width: 1440, height: 900 } });
+
+    test("marks only the page you are on, not its section root", async ({
+      page,
+    }) => {
+      // Overview's href is a prefix of every other Platform tab, so a prefix test
+      // reports it active everywhere in the section. The drawer fills the active
+      // row's background, which makes two selected rows plainly visible.
+      await dashboardPage.gotoUsers();
+
+      const nav = page.locator("header nav");
+      await expect(nav.getByRole("link", { name: "Users" })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+      await expect(
+        nav.getByRole("link", { name: "Overview" }),
+      ).not.toHaveAttribute("aria-current", "page");
+    });
+
+    test("marks Overview on the platform root itself", async ({ page }) => {
+      await page.goto("/dashboard/platform");
+
+      const nav = page.locator("header nav");
+      await expect(nav.getByRole("link", { name: "Overview" })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+    });
+  });
+
   test.describe("on a tablet viewport", () => {
     test.use({ viewport: { width: 900, height: 900 } });
 

--- a/ui/tests/e2e/top-nav-responsive.spec.ts
+++ b/ui/tests/e2e/top-nav-responsive.spec.ts
@@ -80,6 +80,25 @@ test.describe("Top nav responsiveness", () => {
 
       await expect(drawer).toBeHidden();
     });
+
+    test("closes the drawer on navigation it did not initiate", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoUsers();
+      await page.getByRole("button", { name: "Open navigation" }).click();
+
+      const drawer = page.getByRole("dialog");
+      await drawer.getByRole("link", { name: "Overview" }).click();
+      await expect(drawer).toBeHidden();
+
+      // Re-open, then leave by a route change the drawer knows nothing about.
+      await page.getByRole("button", { name: "Open navigation" }).click();
+      await expect(drawer).toBeVisible();
+
+      await page.goBack();
+
+      await expect(drawer).toBeHidden();
+    });
   });
 
   test.describe("on a tablet viewport", () => {

--- a/ui/tests/e2e/top-nav-responsive.spec.ts
+++ b/ui/tests/e2e/top-nav-responsive.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "@playwright/test";
+
+import { DataSupport } from "../pages/data-support/data-support.po";
+import { DashboardPage } from "../pages/dashboard-page.po";
+
+/**
+ * The top nav is a single flex row whose children default to `min-width: auto`,
+ * so without explicit shrink rules it forces the page wider than the viewport
+ * instead of adapting. Below `lg` the tabs move into a drawer; at `lg` and up
+ * they stay inline. `lg` is the threshold because Platform view needs ~1079px
+ * to lay its tabs out at full spacing, so every tablet width gets the drawer.
+ * These specs pin the outcomes — the page never scrolls sideways and every tab
+ * stays reachable — not the utilities behind them.
+ */
+test.describe("Top nav responsiveness", () => {
+  let dashboardPage: DashboardPage;
+  let dataSupportPage: DataSupport;
+
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async ({ page }) => {
+    dashboardPage = new DashboardPage(page);
+    dataSupportPage = new DataSupport(page);
+
+    await dataSupportPage.auth.interceptRefreshRequest();
+    await dataSupportPage.users.interceptGetUserContextRequest();
+    await dataSupportPage.users.interceptGetOrganizationsRequest();
+    await dataSupportPage.agents.interceptGetAgentsRequest();
+    await dataSupportPage.agents.interceptGetAgentHealthRequest();
+  });
+
+  const horizontalOverflow = (page: import("@playwright/test").Page) =>
+    page.evaluate(() => {
+      const root = document.documentElement;
+      return root.scrollWidth - root.clientWidth;
+    });
+
+  test.describe("on a mobile viewport", () => {
+    test.use({ viewport: { width: 375, height: 812 } });
+
+    test("does not scroll the organization view horizontally", async ({
+      page,
+    }) => {
+      await dashboardPage.goto();
+      await expect(page.locator("header")).toBeVisible();
+
+      expect(await horizontalOverflow(page)).toBe(0);
+    });
+
+    test("does not scroll the platform view horizontally", async ({ page }) => {
+      // Platform view carries the most tabs, so it overflows first.
+      await dashboardPage.gotoUsers();
+      await expect(page.locator("header")).toBeVisible();
+
+      expect(await horizontalOverflow(page)).toBe(0);
+    });
+
+    test("collapses the tabs into a navigation drawer", async ({ page }) => {
+      await dashboardPage.gotoUsers();
+
+      // The inline tab row is hidden; the trigger replaces it.
+      await expect(page.locator("header nav")).toBeHidden();
+
+      const trigger = page.getByRole("button", { name: "Open navigation" });
+      await expect(trigger).toBeVisible();
+      await trigger.click();
+
+      const drawer = page.getByRole("dialog");
+      await expect(drawer).toBeVisible();
+      await expect(drawer.getByRole("link", { name: "Organizations" })).toBeVisible();
+    });
+
+    test("closes the drawer when a destination is chosen", async ({ page }) => {
+      await dashboardPage.gotoUsers();
+
+      await page.getByRole("button", { name: "Open navigation" }).click();
+
+      const drawer = page.getByRole("dialog");
+      await drawer.getByRole("link", { name: "Overview" }).click();
+
+      await expect(drawer).toBeHidden();
+    });
+  });
+
+  test.describe("on a tablet viewport", () => {
+    test.use({ viewport: { width: 900, height: 900 } });
+
+    test("uses the drawer rather than cutting the tab row off", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoUsers();
+
+      await expect(page.locator("header nav")).toBeHidden();
+      await expect(
+        page.getByRole("button", { name: "Open navigation" }),
+      ).toBeVisible();
+
+      expect(await horizontalOverflow(page)).toBe(0);
+    });
+  });
+
+  test.describe("at the narrowest inline width", () => {
+    test.use({ viewport: { width: 1024, height: 900 } });
+
+    test("fits every tab without an internal scroll", async ({ page }) => {
+      await dashboardPage.gotoUsers();
+
+      const nav = page.locator("header nav");
+      await expect(nav).toBeVisible();
+
+      const navCutOff = await nav.evaluate(
+        (el) => el.scrollWidth > el.clientWidth,
+      );
+
+      expect(navCutOff).toBe(false);
+      expect(await horizontalOverflow(page)).toBe(0);
+    });
+  });
+
+  test.describe("on a desktop viewport", () => {
+    test.use({ viewport: { width: 1440, height: 900 } });
+
+    test("keeps the tabs inline and hides the drawer trigger", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoUsers();
+
+      const nav = page.locator("header nav");
+      await expect(nav).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Open navigation" }),
+      ).toBeHidden();
+
+      const navOverflows = await nav.evaluate(
+        (el) => el.scrollWidth > el.clientWidth,
+      );
+
+      expect(navOverflows).toBe(false);
+      expect(await horizontalOverflow(page)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #154 

## Problem

The header is a single flex row whose children default to `min-width: auto`, so
nothing could shrink below its content width. Platform view needs ~1079px to lay
its seven tabs out inline, so a 375px viewport forced the document to 962px and
the whole page scrolled sideways.

## Change

- Tabs collapse into a `Sheet` drawer below `lg` (1024px), covering phones and tablets
- Header spacing tightens between `lg` and `xl` so all seven tabs fit at 1024px
- Drawer open state is derived from the current route, so back/forward, the org
  switcher and programmatic navigation all close it
- Brand wordmark and the "Hire agent" label collapse below `sm`

## Checks

- `pnpm exec tsc --noEmit` clean
- `pnpm lint` clean
- `pnpm exec playwright test` 251 passed (including 8 new specs)