### PR TITLE
AF-293: make client release bundle deployable

### DIFF
--- a/.env.deploy.spec
+++ b/.env.deploy.spec
@@ -128,6 +128,17 @@ AGENT_MODEL_ALLOWLIST=
 # e.g. litellm/openrouter/z-ai/glm-5.2. Empty uses the API's built-in default.
 AGENT_DEFAULT_MODEL=
 
+# ── Monitoring (Prometheus + Grafana + Alertmanager) ─────────────────────────
+# Set to false to skip the monitoring release. The values below are still read
+# when the helmfile renders, so leave the placeholders in place when disabled.
+MONITORING_ENABLED=true
+# Hostname the Grafana ingress serves (needs DNS + cert-manager like API_HOST).
+GRAFANA_HOST=grafana.agentbarn.local
+GRAFANA_ADMIN_PASSWORD=change-me
+# Slack incoming webhook (https://hooks.slack.com/services/...) Alertmanager posts to. Any URL keeps the config
+# valid but undeliverable.
+SLACK_ALERTS_WEBHOOK_URL=https://example.invalid/slack-webhook-placeholder
+
 # ── Optional ─────────────────────────────────────────────────────────────────
 # Kubeconfig the API pod uses to manage agent workloads. Defaults to base64 of
 # $KUBECONFIG (deploy.sh derives it). Set only if the API pod must use a

--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -11,6 +11,11 @@ on:
         description: Release tag for API and UI images (e.g. v0.15.0)
         required: true
         type: string
+      image_prefix:
+        description: Path prefix under the client registry (tenant ACL scope)
+        required: false
+        default: agent-barn
+        type: string
 
 concurrency:
   group: client-release
@@ -79,7 +84,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ vars.CLIENT_REGISTRY_URL }}/agent-barn/${{ matrix.name }}
+          images: ${{ vars.CLIENT_REGISTRY_URL }}/${{ inputs.image_prefix }}/${{ matrix.name }}
           tags: |
             type=raw,value=${{ steps.ver.outputs.version }}
             type=raw,value=latest
@@ -103,7 +108,7 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}/${{ matrix.smoke }}:/smoke-test.sh:ro" \
-            "${{ vars.CLIENT_REGISTRY_URL }}/agent-barn/${{ matrix.name }}:${{ steps.ver.outputs.version }}" \
+            "${{ vars.CLIENT_REGISTRY_URL }}/${{ inputs.image_prefix }}/${{ matrix.name }}:${{ steps.ver.outputs.version }}" \
             /bin/sh /smoke-test.sh
 
       - name: Push

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -11,6 +11,11 @@ on:
       tag:
         description: Release tag (e.g. v0.15.0)
         required: true
+      image_prefix:
+        description: Path prefix under the client registry; must match the Client Release run
+        required: false
+        default: agent-barn
+        type: string
 
 permissions:
   contents: write
@@ -43,7 +48,7 @@ jobs:
           # and pin image tags. Credentials are intentionally left blank for the
           # client to fill in.
           sed \
-            -e 's|^REGISTRY_PREFIX=.*|REGISTRY_PREFIX=clients.registry.k8s.aai-labs.com/agent-barn|' \
+            -e 's|^REGISTRY_PREFIX=.*|REGISTRY_PREFIX=clients.registry.k8s.aai-labs.com/${{ inputs.image_prefix }}|' \
             -e 's|^REGISTRY_SERVER=.*|REGISTRY_SERVER=clients.registry.k8s.aai-labs.com|' \
             -e 's|^API_IMAGE_REPOSITORY=.*|API_IMAGE_REPOSITORY=api|' \
             -e 's|^UI_IMAGE_REPOSITORY=.*|UI_IMAGE_REPOSITORY=ui|' \

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -246,6 +246,9 @@ releases:
   - name: monitoring
     namespace: {{ env "NAMESPACE" | default "agent-farm" }}
     chart: ./helm/monitoring
+    # Self-host clients can opt out (MONITORING_ENABLED=false). The block below
+    # is still rendered, so its required inputs need placeholder values.
+    installed: {{ env "MONITORING_ENABLED" | default "true" | eq "true" }}
     labels:
       name: monitoring
     set:


### PR DESCRIPTION
Make the v0.17.0 client bundle deployable: the helmfile requires monitoring inputs the generated `.env.deploy` never carried, and the rebranded `agent-barn/*` registry path is not yet allowed by the tenant ACL.

**What's included**
- **helmfile.yaml.gotmpl** — `installed:` on the monitoring release via `MONITORING_ENABLED` (default `true`). Existing deploys are unchanged.
- **.env.deploy.spec** — add `MONITORING_ENABLED`, `GRAFANA_HOST`, `GRAFANA_ADMIN_PASSWORD`, `SLACK_ALERTS_WEBHOOK_URL` with placeholders and guidance.
- **.github/workflows/client-release.yml, release-bundle.yml** — `image_prefix` input (default `agent-barn`). Passing `agent-farm` publishes to the path existing client credentials already allow; the bundle's `REGISTRY_PREFIX` follows the same input.

**Required repo config**
none

**Notes**
- No app code or chart files changed, so no chart version bump.
- Registry ACL extension for `agent-barn/*` is an infra change in `k3s-hetzner-cluster-infra`, not part of this PR.
- Targets `main` because the change is needed for a client release cut from `main`.

**Testing**
- `helmfile -f helmfile.yaml.gotmpl list` with `MONITORING_ENABLED` unset, `true`, `false`: monitoring shows `INSTALLED=true / true / false`, all other releases unchanged.
- Workflow files parsed as YAML.
