### PR TITLE
AF-174: per-agent cost trend and an agents-by-spend table

### DIFF
--- a/api/domains/costs/models.py
+++ b/api/domains/costs/models.py
@@ -317,6 +317,22 @@ class OrganizationSpendRead(PydanticBaseModel):
     agents: int
 
 
+class AgentSpendRead(PydanticBaseModel):
+    """One Agent's slice of organization spend, for the ranked table.
+
+    `agent_id` is None for the unattributed bucket, kept in the ranking rather than
+    filtered out: hiding it would let the organization total silently exceed the sum
+    of the rows shown beneath it.
+    """
+
+    agent_id: UUID | None = None
+    agent_name: str | None = None
+    spend: float
+    calls: int
+    prompt_tokens: int
+    completion_tokens: int
+
+
 class PlatformCostSummaryRead(CostSummaryRead):
     """The org summary plus the figures only a platform admin sees."""
 

--- a/api/domains/costs/models.py
+++ b/api/domains/costs/models.py
@@ -114,6 +114,12 @@ class CostRecord(BaseModel, table=True):
 # ---------------------------------------------------------------------------
 
 
+class CostSeriesPoint(PydanticBaseModel):
+    bucket: datetime
+    spend: float
+    calls: int
+
+
 class AgentModelBreakdown(PydanticBaseModel):
     model: str
     total_cost: float
@@ -122,7 +128,7 @@ class AgentModelBreakdown(PydanticBaseModel):
 
 
 class AgentCostRead(PydanticBaseModel):
-    """Cost totals for a single agent."""
+    """Cost totals and spend trend for a single agent."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -130,11 +136,18 @@ class AgentCostRead(PydanticBaseModel):
     agent_name: str
     model: str
     status: str
+
+    period: StatsPeriod | None = None
+    from_date: datetime
+    to_date: datetime
+    granularity: StatsGranularity
+
     total_cost: float
     total_tokens: int
     prompt_tokens: int
     completion_tokens: int
     models_breakdown: list[AgentModelBreakdown] = Field(default_factory=list)
+    spend_over_time: list[CostSeriesPoint] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -232,12 +245,6 @@ class PlatformCostRecordRead(CostRecordRead):
 
     organization_id: UUID | None = None
     organization_name: str | None = None
-
-
-class CostSeriesPoint(PydanticBaseModel):
-    bucket: datetime
-    spend: float
-    calls: int
 
 
 class AgentSpendSeriesPoint(PydanticBaseModel):

--- a/api/domains/costs/repository.py
+++ b/api/domains/costs/repository.py
@@ -520,6 +520,32 @@ class CostRepository:
             rows = connection.execute(query).all()
         return [(row[0], row[1], Decimal(str(row[2])), int(row[3]), int(row[4])) for row in rows]
 
+    def spend_by_agent(
+        self,
+        window: StatsWindow,
+        filters: CostFilter,
+    ) -> list[tuple[UUID | None, str | None, Decimal, int, int, int]]:
+        """Agents ranked by spend, biggest first.
+        Unlike `spend_by_agent_series` this is not capped.
+        """
+        # sa.select: sqlmodel's typed overloads stop short of five columns.
+        query = (
+            sa.select(
+                col(CostRecord.agent_id),
+                sa.func.max(col(CostRecord.agent_name)),
+                sa.func.coalesce(sa.func.sum(col(CostRecord.spend)), 0).label("spend"),
+                sa.func.count(),
+                sa.func.coalesce(sa.func.sum(col(CostRecord.prompt_tokens)), 0),
+                sa.func.coalesce(sa.func.sum(col(CostRecord.completion_tokens)), 0),
+            )
+            .where(*self._predicates(window, filters))
+            .group_by(col(CostRecord.agent_id))
+            .order_by(sa.desc("spend"))
+        )
+        with self.delegate.engine.connect() as connection:
+            rows = connection.execute(query).all()
+        return [(row[0], row[1], Decimal(str(row[2])), int(row[3]), int(row[4]), int(row[5])) for row in rows]
+
     def unattributed_totals(self, window: StatsWindow, filters: CostFilter) -> tuple[Decimal, int]:
         """Spend that resolved to no agent — the honest gap in attribution.
 

--- a/api/domains/costs/routes.py
+++ b/api/domains/costs/routes.py
@@ -8,6 +8,7 @@ from api.domains.auth.models import CurrentUserContext
 from api.domains.auth.utils import get_current_user
 from api.domains.costs.models import (
     AgentCostRead,
+    AgentSpendRead,
     CostFilter,
     CostFilterOption,
     CostRecordRead,
@@ -67,6 +68,22 @@ def list_model_filter_options(
     filters: Annotated[CostFilter, Depends(get_cost_filter)],
 ):
     return service.list_org_model_options(context, window, filters)
+
+
+@costs_router.get("/agents", response_model=list[AgentSpendRead])
+def list_agent_spend(
+    context: Annotated[CurrentUserContext, Depends(get_current_user())],
+    service: Annotated[CostService, Injected(CostService)],
+    window: Annotated[StatsWindow, Depends(get_stats_window)],
+    filters: Annotated[CostFilter, Depends(get_cost_filter)],
+):
+    """Agents ranked by spend, biggest first.
+
+    The shared filter carries a sort direction, which this route ignores: the ranking
+    is always by spend, and the table re-sorts the whole list client-side rather than
+    refetching, so there is no server ordering for a caller to choose.
+    """
+    return service.list_org_agent_spend(context, window, filters)
 
 
 @costs_router.get("/agents/{agent_id}", response_model=AgentCostRead)

--- a/api/domains/costs/service.py
+++ b/api/domains/costs/service.py
@@ -151,12 +151,19 @@ class CostService:
         filters = CostFilter(organization_id=agent.organization_id, agent_id=agent.id)
         totals = self.repository.totals(window, filters)
         breakdown = self.repository.model_breakdown(window, filters)
+        # Same series builder the organization summary uses; the filter above pins it
+        # to this agent, so the trend and the totals beside it describe one set of calls.
+        series = self.repository.spend_series(window, filters)
 
         return AgentCostRead(
             agent_id=agent.id,
             agent_name=agent.name,
             model=agent.model,
             status=_display_status(agent),
+            period=window.period,
+            from_date=window.start,
+            to_date=window.end,
+            granularity=window.granularity,
             total_cost=float(totals.spend),
             total_tokens=totals.prompt_tokens + totals.completion_tokens,
             prompt_tokens=totals.prompt_tokens,
@@ -169,6 +176,9 @@ class CostService:
                     completion_tokens=completion_tokens,
                 )
                 for model, spend, prompt_tokens, completion_tokens in breakdown
+            ],
+            spend_over_time=[
+                CostSeriesPoint(bucket=bucket, spend=float(spend), calls=calls) for bucket, spend, calls in series
             ],
         )
 

--- a/api/domains/costs/service.py
+++ b/api/domains/costs/service.py
@@ -12,6 +12,7 @@ from api.domains.auth.models import CurrentUserContext
 from api.domains.costs.models import (
     AgentCostRead,
     AgentModelBreakdown,
+    AgentSpendRead,
     AgentSpendSeriesPoint,
     CostFilter,
     CostFilterOption,
@@ -118,6 +119,33 @@ class CostService:
         return [
             CostFilterOption(value=model, label=model.split("/")[-1])
             for model in self.repository.distinct_models(window, scoped)
+        ]
+
+    def list_org_agent_spend(
+        self,
+        context: CurrentUserContext,
+        window: StatsWindow,
+        filters: CostFilter,
+    ) -> list[AgentSpendRead]:
+        """Every Agent that spent anything in the window, ranked.
+
+        Organization-wide, so it takes the Organization `cost.read` the summary takes
+        rather than a per-Agent check: the caller is asking about the whole
+        organization's spend, not about one Agent they have been assigned.
+        """
+        scoped = self._scoped(self._authorized_org(context), filters)
+        return [
+            AgentSpendRead(
+                agent_id=agent_id,
+                agent_name=agent_name,
+                spend=float(spend),
+                calls=calls,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
+            for agent_id, agent_name, spend, calls, prompt_tokens, completion_tokens in (
+                self.repository.spend_by_agent(window, scoped)
+            )
         ]
 
     def get_agent_cost(

--- a/api/tests/integration/test_costs.py
+++ b/api/tests/integration/test_costs.py
@@ -303,6 +303,32 @@ def test_get_agent_cost_returns_200_and_data():
             assert_that(data["models_breakdown"], has_length(1))
 
 
+def test_agent_spend_list_ranks_agents_by_spend():
+    with given([*_GIVEN, there_are_cost_records(count=2, spend="1.25")]) as context:
+        client: TestClient = context.client
+
+        with when("I list agent spend for the organization"):
+            response = client.get(f"{_BASE}/agents", headers=_auth(context))
+
+        with then("it returns one row per agent with its totals"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            rows = response.json()
+            assert_that(rows, has_length(1))
+            assert_that(rows[0]["agent_id"], equal_to(str(context.agent.id)))
+            assert_that(rows[0]["spend"], close_to(2.5, 0.0001))
+            assert_that(rows[0]["calls"], equal_to(2))
+            assert_that(rows[0]["prompt_tokens"], greater_than(0))
+
+
+def test_member_cannot_list_agent_spend():
+    """The ranked table is Organization-wide, so it takes the Organization `cost.read`
+    the summary takes rather than a per-Agent check."""
+    member_id = uuid7()
+    with given([*_GIVEN, _there_is_a_member_actor(member_id)]) as context:
+        response = context.client.get(f"{_BASE}/agents", headers=_auth(context))
+        assert_that(response.status_code, equal_to(status.HTTP_403_FORBIDDEN))
+
+
 def test_agent_cost_includes_a_spend_trend_for_the_agent():
     """The per-Agent surface carries its own trend.
 

--- a/api/tests/integration/test_costs.py
+++ b/api/tests/integration/test_costs.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from uuid import uuid7
 
 from fastapi import status
-from hamcrest import assert_that, equal_to, has_length
+from hamcrest import assert_that, close_to, equal_to, greater_than, has_length, not_none
 from sqlalchemy import text
 from starlette.testclient import TestClient
 
@@ -301,6 +301,38 @@ def test_get_agent_cost_returns_200_and_data():
             assert_that(data["agent_id"], equal_to(agent_id))
             assert_that(data["prompt_tokens"], equal_to(200))
             assert_that(data["models_breakdown"], has_length(1))
+
+
+def test_agent_cost_includes_a_spend_trend_for_the_agent():
+    """The per-Agent surface carries its own trend.
+
+    The organization summary also has one, but it is gated on the Organization-wide
+    `cost.read` an Agent Access Role never grants, so a per-Agent view cannot source
+    its chart from there.
+    """
+    with given(
+        [
+            *_GIVEN,
+            there_are_cost_records(count=1, spend="3.00", minutes_ago=5),
+            there_are_cost_records(count=1, spend="1.00", minutes_ago=60 * 24 * 3),
+        ]
+    ) as context:
+        client: TestClient = context.client
+        agent_id = str(context.agent.id)
+
+        with when("I request the individual agent cost"):
+            response = client.get(f"{_BASE}/agents/{agent_id}", headers=_auth(context))
+
+        with then("it returns a bucketed series and the window it was grouped at"):
+            assert_that(response.status_code, equal_to(status.HTTP_200_OK))
+            data = response.json()
+            assert_that(data["granularity"], not_none())
+            assert_that(data["from_date"], not_none())
+            assert_that(data["to_date"], not_none())
+            series = data["spend_over_time"]
+            assert_that(len(series), greater_than(0))
+            assert_that(sum(point["spend"] for point in series), close_to(4.0, 0.0001))
+            assert_that(sum(point["calls"] for point in series), equal_to(2))
 
 
 def test_agent_cost_respects_the_requested_window():

--- a/docs/features/costs.md
+++ b/docs/features/costs.md
@@ -41,6 +41,7 @@ Reading the proxy at request time — the earlier arrangement — meant a failed
 ### Reads
 
 - Every aggregate and the row list run through the same predicate, so a stat card and the table beneath it cannot describe different sets of calls.
+- The ranked Agent table is not capped, unlike the per-Agent series behind the chart: a line per Agent stops being readable after a handful, but a table has to account for every Agent that spent anything. It keeps the unattributed bucket for the same reason the Organization ranking does.
 - On the org surface `organization_id` is pinned by the route and never read from the query string.
 - The platform surface has its own routes, service and read model. The org surface must have no code path that can return another organization's name or spend.
 - The unattributed bucket stays inside platform totals and is also reported separately. Excluding it would make the platform total exceed the sum of the organizations listed beneath it.

--- a/docs/features/costs.md
+++ b/docs/features/costs.md
@@ -53,6 +53,7 @@ Reading the proxy at request time — the earlier arrangement — meant a failed
 - Organization cost summaries require the Organization Permission `cost.read`; fixed Organization Owner/Admin roles receive it. An Agent Access Role never authorizes an Organization-wide summary.
 - Per-Agent detail requires `cost.read` through the effective Agent Access Role. Agent Viewer, Editor and Owner can read accessible active-Agent costs; Organization Owner/Admin may also read deleted-Agent history.
 - Per-Agent detail respects the requested window. It previously read `/key/info`, which is lifetime spend and ignores the date range.
+- Per-Agent detail carries its own spend trend, built from the same series query the Organization summary uses under an Agent-pinned filter. It is not read from the summary: that surface requires the Organization-wide `cost.read` an Agent Access Role never grants, so an Agent Viewer or Editor could not load it. The response echoes the resolved window and granularity, because a chart cannot label a bucket without knowing the resolution it was grouped at.
 - Cost-facing status is mapped to `active`, `stopped`, `error` or `deleted`; it is not the persisted AgentStatus enum.
 - Every platform route requires `require_platform_admin`. Nothing re-scopes by membership, because a platform admin deliberately has none.
 

--- a/ui/src/features/agents/components/about-tab.tsx
+++ b/ui/src/features/agents/components/about-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
 
+import { DateRangePicker } from "@/components/date-range-picker";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError } from "@/shared/api/error/errors";
 import { SpendOverTimeChart } from "@/features/costs/components/spend-over-time-chart";
@@ -11,18 +11,16 @@ import {
   formatTokens,
 } from "@/features/costs/format";
 import { useAgentCost } from "@/features/costs/hooks/use-agent-cost";
+import { useCostUrlFilters } from "@/features/costs/hooks/use-cost-url-filters";
 import type { Agent } from "../schemas";
 
-const PERIODS = [
-  { value: "SEVEN_DAYS", label: "7 days" },
-  { value: "THIRTY_DAYS", label: "30 days" },
-  { value: "NINETY_DAYS", label: "90 days" },
-] as const;
+const DATE_FILTER_DEFAULTS = { from: "", to: "" };
 
 export function AboutTab({ agent }: { agent: Agent }) {
-  const [period, setPeriod] = useState<string>("THIRTY_DAYS");
+  const [dateFilters, setDateFilters] = useCostUrlFilters(DATE_FILTER_DEFAULTS);
   const { agentCost, isLoadingAgentCost, error } = useAgentCost(agent.id, {
-    period,
+    fromDate: dateFilters.from || undefined,
+    toDate: dateFilters.to || undefined,
   });
 
   return (
@@ -41,29 +39,16 @@ export function AboutTab({ agent }: { agent: Agent }) {
             </p>
           </div>
 
-          <div
-            className="flex gap-0.5 rounded-lg p-0.5"
-            style={{ background: "var(--bg-soft)" }}
-            role="group"
-            aria-label="Period"
-          >
-            {PERIODS.map(({ value, label }) => (
-              <button
-                key={value}
-                type="button"
-                className="rounded-md px-2.5 py-1 text-[12.5px] transition-colors"
-                style={{
-                  background: period === value ? "var(--bg-elev)" : "transparent",
-                  color: period === value ? "var(--ink)" : "var(--ink-3)",
-                  fontWeight: period === value ? 600 : 500,
-                }}
-                aria-pressed={period === value}
-                onClick={() => setPeriod(value)}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
+          <DateRangePicker
+            from={dateFilters.from}
+            to={dateFilters.to}
+            onChange={(from, to) =>
+              setDateFilters({ from: from || null, to: to || null })
+            }
+            placeholder="All dates"
+            width="16rem"
+            ariaLabel="Date range"
+          />
         </div>
 
         {error ? (

--- a/ui/src/features/agents/components/about-tab.tsx
+++ b/ui/src/features/agents/components/about-tab.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 
+import { format } from "date-fns";
+
 import { DateRangePicker } from "@/components/date-range-picker";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError } from "@/shared/api/error/errors";
@@ -23,6 +25,13 @@ export function AboutTab({ agent }: { agent: Agent }) {
     toDate: dateFilters.to || undefined,
   });
 
+  const resolvedWindowLabel = agentCost
+    ? `${format(new Date(agentCost.fromDate), "MMM d, yyyy")} – ${format(
+        new Date(agentCost.toDate),
+        "MMM d, yyyy",
+      )}`
+    : "Loading…";
+
   return (
     <div className="flex flex-col gap-4">
       <div className="af-card p-4">
@@ -35,7 +44,7 @@ export function AboutTab({ agent }: { agent: Agent }) {
               Spend over time
             </h2>
             <p className="m-0 mt-1 text-[12px]" style={{ color: "var(--ink-4)" }}>
-              What this agent has cost, by day.
+              What this agent has cost.
             </p>
           </div>
 
@@ -45,7 +54,7 @@ export function AboutTab({ agent }: { agent: Agent }) {
             onChange={(from, to) =>
               setDateFilters({ from: from || null, to: to || null })
             }
-            placeholder="All dates"
+            placeholder={resolvedWindowLabel}
             width="16rem"
             ariaLabel="Date range"
           />

--- a/ui/src/features/agents/components/about-tab.tsx
+++ b/ui/src/features/agents/components/about-tab.tsx
@@ -1,13 +1,186 @@
-export function AboutTab() {
+"use client";
+
+import { useState } from "react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { ApiError } from "@/shared/api/error/errors";
+import { SpendOverTimeChart } from "@/features/costs/components/spend-over-time-chart";
+import {
+  formatModelLabel,
+  formatSpend,
+  formatTokens,
+} from "@/features/costs/format";
+import { useAgentCost } from "@/features/costs/hooks/use-agent-cost";
+import type { Agent } from "../schemas";
+
+const PERIODS = [
+  { value: "SEVEN_DAYS", label: "7 days" },
+  { value: "THIRTY_DAYS", label: "30 days" },
+  { value: "NINETY_DAYS", label: "90 days" },
+] as const;
+
+export function AboutTab({ agent }: { agent: Agent }) {
+  const [period, setPeriod] = useState<string>("THIRTY_DAYS");
+  const { agentCost, isLoadingAgentCost, error } = useAgentCost(agent.id, {
+    period,
+  });
+
   return (
-    <div
-      className="flex flex-col items-center justify-center text-center py-20 rounded-2xl"
-      style={{ border: "1px dashed var(--line-strong)" }}
-    >
-      <div className="text-3xl mb-3">🚧</div>
-      <div className="font-medium text-[0.9375rem] mb-1" style={{ color: "var(--ink)" }}>Coming soon</div>
-      <div className="text-[0.844rem] mb-5" style={{ color: "var(--ink-3)" }}>
-        Skills, template metadata, and cost breakdown will appear here soon.
+    <div className="flex flex-col gap-4">
+      <div className="af-card p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2
+              className="m-0 text-[14px] font-semibold"
+              style={{ color: "var(--ink)" }}
+            >
+              Spend over time
+            </h2>
+            <p className="m-0 mt-1 text-[12px]" style={{ color: "var(--ink-4)" }}>
+              What this agent has cost, by day.
+            </p>
+          </div>
+
+          <div
+            className="flex gap-0.5 rounded-lg p-0.5"
+            style={{ background: "var(--bg-soft)" }}
+            role="group"
+            aria-label="Period"
+          >
+            {PERIODS.map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                className="rounded-md px-2.5 py-1 text-[12.5px] transition-colors"
+                style={{
+                  background: period === value ? "var(--bg-elev)" : "transparent",
+                  color: period === value ? "var(--ink)" : "var(--ink-3)",
+                  fontWeight: period === value ? 600 : 500,
+                }}
+                aria-pressed={period === value}
+                onClick={() => setPeriod(value)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error ? (
+          <div
+            className="flex h-[260px] items-center justify-center text-[13px]"
+            style={{ color: "var(--ink-4)" }}
+          >
+            {/* A reader without cost access on this Agent is not looking at a
+                failure, so it is not reported as one. */}
+            {error instanceof ApiError && error.status === 403
+              ? "You don't have access to this agent's costs."
+              : "We couldn't load this agent's spend."}
+          </div>
+        ) : isLoadingAgentCost || !agentCost ? (
+          <Skeleton className="h-[260px] w-full" />
+        ) : (
+          <SpendOverTimeChart
+            series={agentCost.spendOverTime}
+            granularity={agentCost.granularity}
+          />
+        )}
+      </div>
+
+      {agentCost && !error && (
+        <div className="grid gap-3 sm:grid-cols-3">
+          <CostStat label="Total spend" value={formatSpend(agentCost.totalCost)} />
+          <CostStat
+            label="Prompt tokens"
+            value={formatTokens(agentCost.promptTokens)}
+          />
+          <CostStat
+            label="Completion tokens"
+            value={formatTokens(agentCost.completionTokens)}
+          />
+        </div>
+      )}
+
+      {agentCost && !error && agentCost.modelsBreakdown.length > 0 && (
+        <div className="af-card p-4" data-testid="agent-cost-by-model">
+          <h2
+            className="m-0 mb-3 text-[14px] font-semibold"
+            style={{ color: "var(--ink)" }}
+          >
+            Spend by model
+          </h2>
+
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-[13px]">
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                    className="py-2 text-left font-medium"
+                    style={{ borderBottom: "1px solid var(--line)", color: "var(--ink-3)" }}
+                  >
+                    Model
+                  </th>
+                  <th
+                    scope="col"
+                    className="py-2 text-right font-medium"
+                    style={{ borderBottom: "1px solid var(--line)", color: "var(--ink-3)" }}
+                  >
+                    Spend
+                  </th>
+                  <th
+                    scope="col"
+                    className="py-2 text-right font-medium"
+                    style={{ borderBottom: "1px solid var(--line)", color: "var(--ink-3)" }}
+                  >
+                    Tokens
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {agentCost.modelsBreakdown.map((entry) => (
+                  <tr key={entry.model}>
+                    <td
+                      className="max-w-[1px] truncate py-2"
+                      style={{ color: "var(--ink-2)" }}
+                      title={entry.model}
+                    >
+                      {formatModelLabel(entry.model)}
+                    </td>
+                    <td
+                      className="py-2 text-right tabular-nums"
+                      style={{ color: "var(--ink)" }}
+                    >
+                      {formatSpend(entry.totalCost)}
+                    </td>
+                    <td
+                      className="py-2 text-right tabular-nums"
+                      style={{ color: "var(--ink-3)" }}
+                    >
+                      {formatTokens(entry.promptTokens + entry.completionTokens)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CostStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="af-card p-4">
+      <div className="text-[12px]" style={{ color: "var(--ink-4)" }}>
+        {label}
+      </div>
+      <div
+        className="mt-1 text-[20px] font-semibold tabular-nums"
+        style={{ color: "var(--ink)" }}
+      >
+        {value}
       </div>
     </div>
   );

--- a/ui/src/features/agents/components/agent-detail-page.tsx
+++ b/ui/src/features/agents/components/agent-detail-page.tsx
@@ -316,7 +316,7 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
             {resolvedTab === "tool-calls" && <ToolCallsTab agent={agent} />}
             {resolvedTab === "logs" && <LogsTab agent={agent} />}
             {resolvedTab === "work" && <WorkTab agent={agent} />}
-            {resolvedTab === "about" && <AboutTab />}
+            {resolvedTab === "about" && <AboutTab agent={agent} />}
           </>
         )}
       </div>

--- a/ui/src/features/costs/components/agents-by-spend.tsx
+++ b/ui/src/features/costs/components/agents-by-spend.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { formatSpend, formatTokens } from "../format";
+import type { AgentSpend } from "../schemas";
+
+type SortKey = "agentName" | "spend" | "calls" | "tokens";
+type SortDirection = "asc" | "desc";
+
+const COLUMNS: { key: SortKey; label: string; numeric: boolean }[] = [
+  { key: "agentName", label: "Agent", numeric: false },
+  { key: "spend", label: "Spend", numeric: true },
+  { key: "calls", label: "Calls", numeric: true },
+  { key: "tokens", label: "Tokens", numeric: true },
+];
+
+const tokensOf = (agent: AgentSpend) => agent.promptTokens + agent.completionTokens;
+
+function valueFor(agent: AgentSpend, key: SortKey): string | number {
+  switch (key) {
+    case "agentName":
+      // Unattributed sorts as its display name rather than sinking to the bottom on
+      // every sort: it is a real row and hiding it would break the total.
+      return (agent.agentName ?? "Unattributed").toLowerCase();
+    case "spend":
+      return agent.spend;
+    case "calls":
+      return agent.calls;
+    case "tokens":
+      return tokensOf(agent);
+  }
+}
+
+/**
+ * Agents ranked by spend, sortable by any column.
+ *
+ * Sorting is client-side: the endpoint returns every agent in the window rather than
+ * a page, so re-sorting is a reorder of data already held, not a refetch.
+ */
+export function AgentsBySpend({
+  agents,
+  isLoading,
+  onSelectAgent,
+  selectedAgentId,
+}: {
+  agents: AgentSpend[];
+  isLoading: boolean;
+  onSelectAgent: (agentId: string | null) => void;
+  selectedAgentId?: string;
+}) {
+  const [sortKey, setSortKey] = useState<SortKey>("spend");
+  const [direction, setDirection] = useState<SortDirection>("desc");
+
+  const sorted = useMemo(() => {
+    const rows = [...agents];
+    rows.sort((a, b) => {
+      const left = valueFor(a, sortKey);
+      const right = valueFor(b, sortKey);
+      if (left === right) return 0;
+      const order = left < right ? -1 : 1;
+      return direction === "asc" ? order : -order;
+    });
+    return rows;
+  }, [agents, sortKey, direction]);
+
+  const toggle = (key: SortKey) => {
+    if (key === sortKey) {
+      setDirection((d) => (d === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(key);
+    // Numbers are most useful biggest-first; names read best A-Z.
+    setDirection(key === "agentName" ? "asc" : "desc");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="af-card mb-6 p-4" data-testid="agents-by-spend-skeleton">
+        <Skeleton className="mb-4 h-4 w-32" />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="mb-2 h-8 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (agents.length === 0) return null;
+
+  return (
+    <div className="af-card mb-6 p-4" data-testid="agents-by-spend">
+      <h2
+        className="m-0 mb-1 text-[14px] font-semibold"
+        style={{ color: "var(--ink)" }}
+      >
+        Agents by spend
+      </h2>
+      <p className="m-0 mb-3 text-[12px]" style={{ color: "var(--ink-4)" }}>
+        Every agent with spend in this period. Select one to filter the page.
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-[13px]">
+          <thead>
+            <tr>
+              {COLUMNS.map(({ key, label, numeric }) => {
+                const active = key === sortKey;
+                return (
+                  <th
+                    key={key}
+                    scope="col"
+                    className={`py-2 font-medium ${numeric ? "text-right" : "text-left"}`}
+                    style={{ borderBottom: "1px solid var(--line)" }}
+                    aria-sort={
+                      active
+                        ? direction === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
+                  >
+                    <button
+                      type="button"
+                      className={`af-hover-bg inline-flex items-center gap-1 rounded px-1.5 py-1 ${
+                        numeric ? "flex-row-reverse" : ""
+                      }`}
+                      style={{ color: active ? "var(--ink)" : "var(--ink-3)" }}
+                      onClick={() => toggle(key)}
+                    >
+                      {label}
+                      {active &&
+                        (direction === "asc" ? (
+                          <ChevronUp size={13} />
+                        ) : (
+                          <ChevronDown size={13} />
+                        ))}
+                    </button>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((agent) => {
+              const id = agent.agentId;
+              const isSelected = !!id && id === selectedAgentId;
+              return (
+                <tr
+                  key={id ?? "unattributed"}
+                  className={id ? "af-hover-bg cursor-pointer" : undefined}
+                  style={{
+                    background: isSelected ? "var(--bg-soft)" : "transparent",
+                  }}
+                  onClick={() => id && onSelectAgent(isSelected ? null : id)}
+                >
+                  <td className="py-2" style={{ color: "var(--ink-2)" }}>
+                    {agent.agentName ?? "Unattributed"}
+                  </td>
+                  <td
+                    className="py-2 text-right tabular-nums"
+                    style={{ color: "var(--ink)" }}
+                  >
+                    {formatSpend(agent.spend)}
+                  </td>
+                  <td
+                    className="py-2 text-right tabular-nums"
+                    style={{ color: "var(--ink-3)" }}
+                  >
+                    {agent.calls.toLocaleString()}
+                  </td>
+                  <td
+                    className="py-2 text-right tabular-nums"
+                    style={{ color: "var(--ink-3)" }}
+                  >
+                    {formatTokens(tokensOf(agent))}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/costs/components/cost-row.tsx
+++ b/ui/src/features/costs/components/cost-row.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { formatCallSpend, formatDuration, formatTokens } from "../format";
+import {
+  formatCallSpend,
+  formatDuration,
+  formatModelLabel,
+  formatTokens,
+} from "../format";
 import type { CostRecord, PlatformCostRecord } from "../schemas";
 
 interface CostRowProps {
@@ -30,7 +35,7 @@ export function CostRow({ record, grid, showOrganization }: CostRowProps) {
       </span>
 
       <span className="truncate" style={{ color: "var(--ink)" }} title={record.model}>
-        {record.model.split("/").at(-1)}
+        {formatModelLabel(record.model)}
       </span>
 
       <span

--- a/ui/src/features/costs/components/cost-summary-cards.tsx
+++ b/ui/src/features/costs/components/cost-summary-cards.tsx
@@ -4,7 +4,12 @@ import type { ReactNode } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
-import { formatCallSpend, formatSpend, formatTokens } from "../format";
+import {
+  formatCallSpend,
+  formatModelLabel,
+  formatSpend,
+  formatTokens,
+} from "../format";
 import type { CostSummary } from "../schemas";
 
 interface CostSummaryCardsProps {
@@ -57,7 +62,7 @@ export function CostSummaryCards({
       />
       <StatCard
         label="Top model"
-        value={summary.topModel ? shortModel(summary.topModel) : "—"}
+        value={summary.topModel ? formatModelLabel(summary.topModel) : "—"}
         hint={summary.topModel ? formatSpend(summary.topModelSpend) : "no spend yet"}
         testId="cost-top-model"
       />
@@ -76,12 +81,6 @@ export function CostSummaryCards({
       {children}
     </div>
   );
-}
-
-/** Provider-qualified ids are too long for a card. The last segment is the name
- *  people actually say. */
-export function shortModel(model: string): string {
-  return model.split("/").at(-1) ?? model;
 }
 
 export function StatCard({

--- a/ui/src/features/costs/components/costs-page.tsx
+++ b/ui/src/features/costs/components/costs-page.tsx
@@ -8,8 +8,10 @@ import { useRequireOrgManager } from "@/features/organizations/hooks/use-require
 import { useCostFilterOptions } from "../hooks/use-cost-filter-options";
 import { useCostSummary } from "../hooks/use-cost-summary";
 import { useCosts } from "../hooks/use-costs";
+import { useAgentSpend } from "../hooks/use-agent-spend";
 import { useCostUrlFilters } from "../hooks/use-cost-url-filters";
 import type { CostFilters } from "../utils";
+import { AgentsBySpend } from "./agents-by-spend";
 import { CostChartsPanel } from "./cost-charts-panel";
 import { CostFilterBar } from "./cost-filter-bar";
 import { CostList } from "./cost-list";
@@ -52,6 +54,14 @@ export function CostsPage() {
     filters.fromDate ||
     filters.toDate
   );
+
+  // The table lists every agent, so it deliberately drops the agent dimension:
+  // filtering it by the selected agent would collapse it to the row just clicked.
+  const agentTableFilters: CostFilters = useMemo(
+    () => ({ ...filters, agentId: undefined }),
+    [filters],
+  );
+  const { agents, isLoadingAgents } = useAgentSpend(agentTableFilters);
 
   const { summary, isLoading: isLoadingSummary, refetch: refetchSummary } =
     useCostSummary(filters);
@@ -126,6 +136,13 @@ export function CostsPage() {
       />
 
       <CostChartsPanel summary={summary} isLoading={isLoadingSummary} />
+
+      <AgentsBySpend
+        agents={agents}
+        isLoading={isLoadingAgents}
+        selectedAgentId={filters.agentId}
+        onSelectAgent={(agentId) => setUrlFilters({ agentId })}
+      />
 
       <p className="text-[13px] mb-3" style={{ color: "var(--ink-4)" }}>
         {total.toLocaleString()} {total === 1 ? "call" : "calls"}

--- a/ui/src/features/costs/format.ts
+++ b/ui/src/features/costs/format.ts
@@ -72,3 +72,10 @@ export function formatDuration(ms: number | null): string {
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(1)}s`;
 }
+
+/** The model as the cost surfaces show it: the slug alone, without its routing path.
+ *  `cost_record.model` stores the full route (e.g. "openrouter/anthropic/claude-opus-5"),
+ *  which is too long to read in a table and identical across rows in its leading parts. */
+export function formatModelLabel(model: string): string {
+  return model.split("/").at(-1) ?? model;
+}

--- a/ui/src/features/costs/hooks/use-agent-cost.ts
+++ b/ui/src/features/costs/hooks/use-agent-cost.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { useOrganizationApiBase } from "@/features/organizations/hooks/use-organization-api-base";
+import { api } from "@/shared/api";
+
+import { AgentCostSchema, type AgentCost } from "../schemas";
+import { costKey } from "../utils";
+
+/**
+ * Spend and trend for one Agent.
+ */
+export function useAgentCost(agentId: string, { period }: { period: string }) {
+  const orgApiBase = useOrganizationApiBase();
+  const query = useQuery({
+    queryKey: costKey.list({
+      scope: { view: "agent", agentId },
+      filters: { period },
+    }),
+    queryFn: async () => {
+      const response = await api.get<AgentCost>(
+        `${orgApiBase}/costs/agents/${agentId}?period=${period}`,
+        { schema: AgentCostSchema },
+      );
+      return response.data;
+    },
+  });
+
+  return {
+    agentCost: query.data ?? null,
+    isLoadingAgentCost: query.isPending,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/ui/src/features/costs/hooks/use-agent-cost.ts
+++ b/ui/src/features/costs/hooks/use-agent-cost.ts
@@ -11,16 +11,25 @@ import { costKey } from "../utils";
 /**
  * Spend and trend for one Agent.
  */
-export function useAgentCost(agentId: string, { period }: { period: string }) {
+export function useAgentCost(
+  agentId: string,
+  { fromDate, toDate }: { fromDate?: string; toDate?: string },
+) {
   const orgApiBase = useOrganizationApiBase();
   const query = useQuery({
     queryKey: costKey.list({
       scope: { view: "agent", agentId },
-      filters: { period },
+      filters: { fromDate: fromDate ?? "", toDate: toDate ?? "" },
     }),
     queryFn: async () => {
+      // Only the window is sent: this route takes a StatsWindow and no filter
+      const params = new URLSearchParams();
+      if (fromDate) params.set("from_date", fromDate);
+      if (toDate) params.set("to_date", toDate);
+      const queryString = params.toString();
+
       const response = await api.get<AgentCost>(
-        `${orgApiBase}/costs/agents/${agentId}?period=${period}`,
+        `${orgApiBase}/costs/agents/${agentId}${queryString ? `?${queryString}` : ""}`,
         { schema: AgentCostSchema },
       );
       return response.data;

--- a/ui/src/features/costs/hooks/use-agent-spend.ts
+++ b/ui/src/features/costs/hooks/use-agent-spend.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { useOrganizationApiBase } from "@/features/organizations/hooks/use-organization-api-base";
+import { api } from "@/shared/api";
+
+import { AgentSpendListSchema, type AgentSpend } from "../schemas";
+import { costFilterParams, costKey, type CostFilters } from "../utils";
+
+/**
+ * Every agent that spent anything in the window, ranked by spend.
+ *
+ * Returned whole rather than paginated — an organization has tens of agents, not
+ * thousands — which is why the table sorts client-side instead of refetching.
+ */
+export function useAgentSpend(filters: CostFilters) {
+  const orgApiBase = useOrganizationApiBase();
+  const query = useQuery({
+    queryKey: costKey.list({ scope: { view: "agent-spend" }, filters }),
+    queryFn: async () => {
+      const response = await api.get<AgentSpend[]>(
+        `${orgApiBase}/costs/agents?${costFilterParams(filters).toString()}`,
+        { schema: AgentSpendListSchema },
+      );
+      return response.data;
+    },
+  });
+
+  return {
+    agents: query.data ?? [],
+    isLoadingAgents: query.isPending,
+    error: query.error,
+  };
+}

--- a/ui/src/features/costs/schemas.ts
+++ b/ui/src/features/costs/schemas.ts
@@ -110,6 +110,17 @@ export const PlatformCostSummarySchema = CostSummarySchema.extend({
   organizations: z.array(OrganizationSpendSchema).default([]),
 });
 
+export const AgentSpendSchema = z.object({
+  agentId: z.string().uuid().nullable().default(null),
+  agentName: z.string().nullable().default(null),
+  spend: z.number(),
+  calls: z.number().int(),
+  promptTokens: z.number().int(),
+  completionTokens: z.number().int(),
+});
+
+export const AgentSpendListSchema = z.array(AgentSpendSchema);
+
 /** Cost totals for a single agent, used by the agent detail surface. */
 export const AgentModelBreakdownSchema = z.object({
   model: z.string(),
@@ -152,3 +163,4 @@ export type CostSummary = z.infer<typeof CostSummarySchema>;
 export type OrganizationSpend = z.infer<typeof OrganizationSpendSchema>;
 export type PlatformCostSummary = z.infer<typeof PlatformCostSummarySchema>;
 export type AgentCost = z.infer<typeof AgentCostSchema>;
+export type AgentSpend = z.infer<typeof AgentSpendSchema>;

--- a/ui/src/features/costs/schemas.ts
+++ b/ui/src/features/costs/schemas.ts
@@ -123,11 +123,16 @@ export const AgentCostSchema = z.object({
   agentName: z.string(),
   model: z.string(),
   status: z.string(),
+  period: z.string().nullable().default(null),
+  fromDate: z.string(),
+  toDate: z.string(),
+  granularity: GranularitySchema,
   totalCost: z.number(),
   totalTokens: z.number().int(),
   promptTokens: z.number().int(),
   completionTokens: z.number().int(),
   modelsBreakdown: z.array(AgentModelBreakdownSchema).default([]),
+  spendOverTime: z.array(CostSeriesPointSchema).default([]),
 });
 
 export type CostSortDirection = z.infer<typeof CostSortDirectionSchema>;

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -1683,7 +1683,11 @@ test.describe("Agent Detail Page — About tab", () => {
     expect(requested.at(-1)?.get("to_date")).toBe("2026-08-31T00:00:00.000Z");
   });
 
-  test("offers the same date range picker as the costs page", async ({ page }) => {
+  test("labels the picker with the window the server actually used", async ({
+    page,
+  }) => {
+    // With no range picked the server applies its own default window, so a static
+    // "All dates" would describe the totals beside it as lifetime when they are not.
     await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
       await route.fulfill({
         status: 200,
@@ -1695,7 +1699,12 @@ test.describe("Agent Detail Page — About tab", () => {
     await agentDetailPage.goto(MOCK_AGENT_ID);
     await page.getByRole("button", { name: "About", exact: true }).click();
 
-    await expect(page.getByRole("button", { name: "Date range" })).toBeVisible();
+    const picker = page.getByRole("button", { name: "Date range" });
+    await expect(picker).toBeVisible();
+    // from_date / to_date in the fixture are 2026-08-01 and 2026-08-31.
+    await expect(picker).toContainText("Aug 1, 2026");
+    await expect(picker).toContainText("Aug 31, 2026");
+    await expect(picker).not.toContainText("All dates");
   });
 
   test("says so plainly when the reader has no cost access to this agent", async ({

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -1528,3 +1528,186 @@ test.describe("Agent Detail Page — Personality tab (approval mode, OpenClaw)",
     await expect(page.getByRole("combobox", { name: "Command approval" })).toHaveCount(0);
   });
 });
+
+test.describe("Agent Detail Page — About tab", () => {
+  let agentDetailPage: AgentDetailPage;
+  let dataSupportPage: DataSupport;
+
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  const agentCost = (overrides: Record<string, unknown> = {}) => ({
+    agent_id: MOCK_AGENT_ID,
+    agent_name: "Maya",
+    model: "openrouter/z-ai/glm-5.2",
+    status: "active",
+    period: "THIRTY_DAYS",
+    from_date: "2026-08-01T00:00:00Z",
+    to_date: "2026-08-31T00:00:00Z",
+    granularity: "day",
+    total_cost: 12.5,
+    total_tokens: 3000,
+    prompt_tokens: 2000,
+    completion_tokens: 1000,
+    models_breakdown: [
+      {
+        model: "litellm/openrouter/z-ai/glm-5.2",
+        total_cost: 9.0,
+        prompt_tokens: 1500,
+        completion_tokens: 700,
+      },
+      {
+        model: "litellm/openrouter/openai/gpt-5-mini",
+        total_cost: 3.5,
+        prompt_tokens: 500,
+        completion_tokens: 300,
+      },
+    ],
+    spend_over_time: [
+      { bucket: "2026-08-01T00:00:00Z", spend: 4.5, calls: 3 },
+      { bucket: "2026-08-02T00:00:00Z", spend: 8.0, calls: 5 },
+    ],
+    ...overrides,
+  });
+
+  test.beforeEach(async ({ page }) => {
+    agentDetailPage = new AgentDetailPage(page);
+    dataSupportPage = new DataSupport(page);
+
+    await dataSupportPage.auth.interceptRefreshRequest();
+    await dataSupportPage.users.interceptGetUserContextRequest();
+    await dataSupportPage.users.interceptGetOrganizationsRequest();
+    await dataSupportPage.agents.interceptGetAgentRequest();
+    await dataSupportPage.agents.interceptGetAgentTemplateRequest();
+    await dataSupportPage.agents.interceptGetAgentHealthRequest();
+    await dataSupportPage.agents.interceptGetConversationChannelsRequest();
+    await dataSupportPage.agents.interceptGetTemplatesRequest();
+    await dataSupportPage.agents.interceptGetAgentConfigurationRequest();
+    await dataSupportPage.agents.interceptGetModelsRequest();
+  });
+
+  test("renders the agent's spend trend and totals", async ({ page }) => {
+    await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(agentCost()),
+      });
+    });
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await page.getByRole("button", { name: "About", exact: true }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Spend over time" }),
+    ).toBeVisible();
+    await expect(page.getByText("$12.50")).toBeVisible();
+  });
+
+  test("breaks the spend down by model, biggest first", async ({ page }) => {
+    await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(agentCost()),
+      });
+    });
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await page.getByRole("button", { name: "About", exact: true }).click();
+
+    const table = page.getByTestId("agent-cost-by-model");
+    await expect(table).toBeVisible();
+
+    // The routing prefix is stripped for display; the server already ranks by spend.
+    const models = await table.locator("tbody tr td:first-child").allInnerTexts();
+    expect(models).toEqual(["glm-5.2", "gpt-5-mini"]);
+    await expect(table.getByText("$9.00")).toBeVisible();
+  });
+
+  test("hides the model breakdown when there is nothing to break down", async ({
+    page,
+  }) => {
+    await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(agentCost({ models_breakdown: [] })),
+      });
+    });
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await page.getByRole("button", { name: "About", exact: true }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Spend over time" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("agent-cost-by-model")).toBeHidden();
+  });
+
+  test("asks the per-agent endpoint again when the period changes", async ({
+    page,
+  }) => {
+    // The chart must not be sourced from the organization summary: that endpoint
+    // needs an Organization-wide permission an Agent Access Role never grants.
+    const requested: string[] = [];
+    await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
+      requested.push(new URL(route.request().url()).searchParams.get("period") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(agentCost()),
+      });
+    });
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await page.getByRole("button", { name: "About", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Spend over time" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "7 days" }).click();
+
+    await expect.poll(() => requested).toContain("SEVEN_DAYS");
+    expect(requested[0]).toBe("THIRTY_DAYS");
+  });
+
+  test("says so plainly when the reader has no cost access to this agent", async ({
+    page,
+  }) => {
+    // A reader without cost access is not looking at a failure, so it must not be
+    // reported as one.
+    await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Forbidden" }),
+      });
+    });
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await page.getByRole("button", { name: "About", exact: true }).click();
+
+    await expect(
+      page.getByText("You don't have access to this agent's costs."),
+    ).toBeVisible();
+  });
+
+  test("surfaces an error instead of an empty chart when spend fails to load", async ({
+    page,
+  }) => {
+    await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Cost service unavailable" }),
+      });
+    });
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await page.getByRole("button", { name: "About", exact: true }).click();
+
+    await expect(
+      page.getByText("We couldn't load this agent's spend."),
+    ).toBeVisible();
+  });
+});

--- a/ui/tests/e2e/agent-detail-page.spec.ts
+++ b/ui/tests/e2e/agent-detail-page.spec.ts
@@ -1644,14 +1644,13 @@ test.describe("Agent Detail Page — About tab", () => {
     await expect(page.getByTestId("agent-cost-by-model")).toBeHidden();
   });
 
-  test("asks the per-agent endpoint again when the period changes", async ({
-    page,
-  }) => {
+  test("reads its window from the date range in the URL", async ({ page }) => {
     // The chart must not be sourced from the organization summary: that endpoint
-    // needs an Organization-wide permission an Agent Access Role never grants.
-    const requested: string[] = [];
+    // needs an Organization-wide permission an Agent Access Role never grants. It
+    // sends only the window, because this route takes no filter.
+    const requested: URLSearchParams[] = [];
     await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
-      requested.push(new URL(route.request().url()).searchParams.get("period") ?? "");
+      requested.push(new URL(route.request().url()).searchParams);
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1665,10 +1664,38 @@ test.describe("Agent Detail Page — About tab", () => {
       page.getByRole("heading", { name: "Spend over time" }),
     ).toBeVisible();
 
-    await page.getByRole("button", { name: "7 days" }).click();
+    // No range picked: the server chooses the window, as "All dates" does on the
+    // costs page.
+    expect(requested[0].get("from_date")).toBeNull();
+    expect(requested[0].get("to_date")).toBeNull();
+    expect(requested[0].get("sort")).toBeNull();
 
-    await expect.poll(() => requested).toContain("SEVEN_DAYS");
-    expect(requested[0]).toBe("THIRTY_DAYS");
+    await page.goto(
+      `/dashboard/${TEST_ORG_ID}/agents/${MOCK_AGENT_ID}?tab=about&from=2026-08-01T00:00:00.000Z&to=2026-08-31T00:00:00.000Z`,
+    );
+    await expect(
+      page.getByRole("heading", { name: "Spend over time" }),
+    ).toBeVisible();
+
+    await expect
+      .poll(() => requested.at(-1)?.get("from_date"))
+      .toBe("2026-08-01T00:00:00.000Z");
+    expect(requested.at(-1)?.get("to_date")).toBe("2026-08-31T00:00:00.000Z");
+  });
+
+  test("offers the same date range picker as the costs page", async ({ page }) => {
+    await page.route(`**/costs/agents/${MOCK_AGENT_ID}*`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(agentCost()),
+      });
+    });
+
+    await agentDetailPage.goto(MOCK_AGENT_ID);
+    await page.getByRole("button", { name: "About", exact: true }).click();
+
+    await expect(page.getByRole("button", { name: "Date range" })).toBeVisible();
   });
 
   test("says so plainly when the reader has no cost access to this agent", async ({

--- a/ui/tests/e2e/costs.spec.ts
+++ b/ui/tests/e2e/costs.spec.ts
@@ -157,3 +157,99 @@ test.describe("Organization costs", () => {
     await expect(page.getByText("Unable to load costs")).toBeVisible();
   });
 });
+
+test.describe("Organization costs — agents by spend", () => {
+  let data: DataSupport;
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  const AGENT_ROWS = [
+    {
+      agent_id: "11111111-1111-4111-8111-111111111111",
+      agent_name: "Zeta",
+      spend: 1.0,
+      calls: 40,
+      prompt_tokens: 100,
+      completion_tokens: 50,
+    },
+    {
+      agent_id: "22222222-2222-4222-8222-222222222222",
+      agent_name: "Alpha",
+      spend: 5.0,
+      calls: 10,
+      prompt_tokens: 900,
+      completion_tokens: 100,
+    },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    data = new DataSupport(page);
+    await data.auth.interceptRefreshRequest();
+    await data.users.interceptGetUserContextRequest();
+    await data.costs.interceptOrgFilterOptions();
+    await data.costs.interceptOrgSummary();
+    await data.costs.interceptOrgList({ items: [costRecord()], total: 1 });
+
+    await page.route("**/costs/agents?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(AGENT_ROWS),
+      });
+    });
+  });
+
+  const agentColumn = (page: import("@playwright/test").Page) =>
+    page
+      .getByTestId("agents-by-spend")
+      .locator("tbody tr td:first-child")
+      .allInnerTexts();
+
+  // Scoped to the table: "Agent" alone also matches the "Hire agent" button in the nav.
+  const sortBy = (page: import("@playwright/test").Page, column: string) =>
+    page.getByTestId("agents-by-spend").getByRole("button", { name: column }).click();
+
+  test("ranks agents by spend by default", async ({ page }) => {
+    await page.goto(COSTS_URL);
+
+    await expect(page.getByTestId("agents-by-spend")).toBeVisible();
+    expect(await agentColumn(page)).toEqual(["Alpha", "Zeta"]);
+  });
+
+  test("sorts by a column and reverses on a second click", async ({ page }) => {
+    await page.goto(COSTS_URL);
+    await expect(page.getByTestId("agents-by-spend")).toBeVisible();
+
+    // Calls order is the inverse of spend order, so this cannot pass by accident.
+    await sortBy(page, "Calls");
+    expect(await agentColumn(page)).toEqual(["Zeta", "Alpha"]);
+
+    await sortBy(page, "Calls");
+    expect(await agentColumn(page)).toEqual(["Alpha", "Zeta"]);
+  });
+
+  test("sorts the agent name alphabetically", async ({ page }) => {
+    await page.goto(COSTS_URL);
+    await expect(page.getByTestId("agents-by-spend")).toBeVisible();
+
+    await sortBy(page, "Agent");
+
+    expect(await agentColumn(page)).toEqual(["Alpha", "Zeta"]);
+    await expect(
+      page.getByTestId("agents-by-spend").getByRole("columnheader", { name: "Agent" }),
+    ).toHaveAttribute("aria-sort", "ascending");
+  });
+
+  test("selecting a row filters the page to that agent and keeps the table whole", async ({
+    page,
+  }) => {
+    await page.goto(COSTS_URL);
+    await expect(page.getByTestId("agents-by-spend")).toBeVisible();
+
+    await page.getByRole("cell", { name: "Alpha", exact: true }).click();
+
+    await expect(page).toHaveURL(/agentId=22222222-2222-4222-8222-222222222222/);
+    // The table drops the agent dimension, so it must still list every agent —
+    // otherwise picking a row would collapse it to the row just picked.
+    expect(await agentColumn(page)).toEqual(["Alpha", "Zeta"]);
+  });
+});


### PR DESCRIPTION
## Problem

An agent's cost was a single total with no way to see how it trended, and there
was no per-agent breakdown of an organization's spend.

## Change

**Agent About tab** replaces the "Coming soon" placeholder with:

- spend over time, reusing `SpendOverTimeChart`
- the same `DateRangePicker` the costs page uses, with the range in the URL
- totals, and a per-model breakdown table, which the endpoint already returned

**Organization costs page** adds "Agents by spend": every agent with spend in
the window, sortable on any column. Selecting a row filters the page to that agent.

**Backend**

- `AgentCostRead` gains `spend_over_time` plus the resolved window, built from
  the existing series query under the Agent-pinned filter `get_agent_cost` already used.
- New `GET /organizations/{org}/costs/agents`, mirroring `spend_by_organization`.
  Uncapped, unlike the chart's series: a line per agent stops being readable
  after a handful, but a table has to account for every agent that spent anything.

## Design notes

- The table sorts client-side. The endpoint returns every agent rather than
  a page, so re-sorting reorders data already held rather than refetching.
- `GET /costs/agents` accepts a `sort` from the shared filter and ignores it;
  the ranking is always by spend. That matches `/summary` and `/filters/*` routes.

## Testing

- `make check-api`, `make check-migrations` pass
- `pytest api/tests/integration/test_costs.py` 24 pass, 4 new
- `pnpm exec tsc --noEmit`, `pnpm lint` clean
- `pnpm exec playwright test` 261 pass, 11 new